### PR TITLE
Updated domain handling and user script with keystone client

### DIFF
--- a/dataporten.py
+++ b/dataporten.py
@@ -8,9 +8,9 @@ from himlarcli import utils as himutils
 options = utils.get_options('Setup dataporten openid mapping',
                              hosts=0, dry_run=True)
 ksclient = Keystone(options.config, debug=options.debug)
-
+ksclient.set_domain('dataporten')
 # Domain should be create from hieradata
-domain = ksclient.get_domain_id('dataporten')
+domain = ksclient.get_domain_id()
 rules = [{
     "local": [{
         "user": { "name": "{0}", "id": "{0}" },

--- a/himlarcli/client.py
+++ b/himlarcli/client.py
@@ -74,9 +74,9 @@ class Client(object):
     def get_logger(self):
         return self.logger
 
-    def log(self, msg):
-        print "client.log is depricated"
-        self.logger.debug(msg)
+    def debug_log(self, msg):
+        prefix = '=> DRY-RUN:' if self.dry_run else '=>'
+        self.logger.debug('%s %s', prefix, msg)
 
     def log_dry_run(self, function, **kwargs):
         if self.dry_run:

--- a/himlarcli/glance.py
+++ b/himlarcli/glance.py
@@ -64,14 +64,20 @@ class Glance(Client):
         self.upload_image(source_path)
         return self.image
 
+    def delete_private_images(self, project_id):
+        images = self.get_images(filters={'owner': project_id})
+        for image in images:
+            self.delete_image(image.id)
+
     def delete_image(self, image_id):
         if not self.image and not image_id:
             self.logger.critical('Image must exist before deletion.')
             return
         if not image_id:
             image_id = self.image.id
-        self.logger.debug('=> image delete %s' % image_id)
-        self.client.images.delete(image_id)
+        self.debug_log('image delete %s' % image_id)
+        if not self.dry_run:
+            self.client.images.delete(image_id)
 
     def update_image(self, name, image_id=None, **kwargs):
         if not self.image and not image_id:

--- a/himlarcli/keystone.py
+++ b/himlarcli/keystone.py
@@ -300,7 +300,9 @@ class Keystone(Client):
             self.log_error('Could not find api user for %s!', old_email)
         self.debug_log('rename api user from %s to %s' % (old_email, new_email))
         if not self.dry_run:
-            self.client.users.update(user=api, name=new_email.lower())
+            self.client.users.update(user=api,
+                                     name=new_email.lower(),
+                                     email=new_email.lower())
         # Rename group
         group = self.get_group_by_email(old_email)
         if not group:
@@ -320,6 +322,7 @@ class Keystone(Client):
                            % (personal.name, new_personal_name))
             if not self.dry_run:
                 self.client.projects.update(project=personal,
+                                            admin=new_email,
                                             name=new_personal_name)
         # Rename old demo project
         new_demo_name = self.get_project_name(new_email, prefix='DEMO')
@@ -329,7 +332,9 @@ class Keystone(Client):
             self.debug_log('rename demo project from %s to %s'
                            % (demo.name, new_demo_name))
             if not self.dry_run:
-                self.client.projects.update(project=demo, name=new_demo_name)
+                self.client.projects.update(project=demo,
+                                            admin=new_email,
+                                            name=new_demo_name)
 
     def reset_password(self, email, domain=None, dry_run=False):
         obj = self.get_user_objects(email=email, domain=domain)

--- a/instance.py
+++ b/instance.py
@@ -13,6 +13,7 @@ parser = Parser()
 options = parser.parse_args()
 
 ksclient = Keystone(options.config, debug=options.debug)
+ksclient.set_domain(options.domain)
 logger = ksclient.get_logger()
 printer = Printer(options.format)
 domain = 'Dataporten'

--- a/object.py
+++ b/object.py
@@ -4,8 +4,6 @@ from himlarcli import tests as tests
 tests.is_virtual_env()
 
 from himlarcli.keystone import Keystone
-from himlarcli.nova import Nova
-from himlarcli.cinder import Cinder
 from himlarcli.parser import Parser
 from himlarcli.printer import Printer
 from himlarcli import utils as himutils
@@ -16,6 +14,7 @@ printer = Printer(options.format)
 
 ksclient = Keystone(options.config, debug=options.debug)
 ksclient.set_dry_run(options.dry_run)
+ksclient.set_domain(options.domain)
 logger = ksclient.get_logger()
 
 if hasattr(options, 'region'):
@@ -27,7 +26,7 @@ if not regions:
     himutils.sys_error('No valid regions found!')
 
 def action_grant():
-    project = ksclient.get_project_by_name(project_name=options.project, domain=options.domain)
+    project = ksclient.get_project_by_name(project_name=options.project)
     if not project:
         himutils.sys_error('No project found with name %s' % options.project)
     users = ksclient.get_users(domain=options.domain, project=project.id)

--- a/project.py
+++ b/project.py
@@ -17,6 +17,7 @@ printer = Printer(options.format)
 
 ksclient = Keystone(options.config, debug=options.debug)
 ksclient.set_dry_run(options.dry_run)
+ksclient.set_domain(options.domain)
 logger = ksclient.get_logger()
 #novaclient = Nova(options.config, debug=options.debug, log=logger)
 if hasattr(options, 'region'):
@@ -79,14 +80,13 @@ def action_create():
 def action_grant():
     if not ksclient.is_valid_user(email=options.user, domain=options.domain):
         himutils.sys_error('User %s not found as a valid user.' % options.user)
-    project = ksclient.get_project_by_name(project_name=options.project, domain=options.domain)
+    project = ksclient.get_project_by_name(project_name=options.project)
     if not project:
         himutils.sys_error('No project found with name %s' % options.project)
     if hasattr(project, 'type') and (project.type == 'demo' or project.type == 'personal'):
         himutils.sys_error('Project are %s. User access not allowed!' % project.type)
     role = ksclient.grant_role(project_name=options.project,
-                               email=options.user,
-                               domain=options.domain)
+                               email=options.user)
     if role:
         output = role.to_dict() if not isinstance(role, dict) else role
         output['header'] = "Roles for %s" % options.project
@@ -117,7 +117,7 @@ def action_list():
     printer.output_dict({'header': 'Project list count', 'count': count})
 
 def action_show():
-    project = ksclient.get_project_by_name(project_name=options.project, domain=options.domain)
+    project = ksclient.get_project_by_name(project_name=options.project)
     if not project:
         himutils.sys_error('No project found with name %s' % options.project)
     output_project = project.to_dict()


### PR DESCRIPTION
## Endringer:
* domain er en global setting i keystone client nå (dvs at den er tatt vekk fra hver endel funksjoner)
* keystone.rename_user() er skrevet helt på nytt
* keystone.remove_user() er ersattet av keystone.user_cleanup(), keystone.delete_user() og keystone.delete_group()
* keystone.delete_project() sletter nå også private images
* pluss endel mindre pylint fikser og debug endringer

## Review:
Viktigste å se er at alle endringer som blir utført tar hensyn til `self.dry_run` når man kaller de underliggende klientene `self.client` (spesielt update/delete).