### PR TITLE
Fix foreman_setup.py

### DIFF
--- a/config/compute_profiles.yaml
+++ b/config/compute_profiles.yaml
@@ -9,7 +9,7 @@
 # 16 GB = 17179869184
 
 default:
-  1: # small
+  small:
     vm_attrs:
       cpus:   '1'
       memory: '2147483648'
@@ -28,7 +28,7 @@ default:
           pool_name:    'dirpool'
           capacity:     '10G'
           format_type:  'qcow2'
-  2: # medium
+  medium:
     vm_attrs:
       cpus:   '1'
       memory: '4294967296'
@@ -47,7 +47,7 @@ default:
           pool_name:    'dirpool'
           capacity:     '10G'
           format_type:  'qcow2'
-  3: # large
+  large:
     vm_attrs:
       cpus:   '2'
       memory: '4294967296'
@@ -66,7 +66,7 @@ default:
           pool_name:    'dirpool'
           capacity:     '10G'
           format_type:  'qcow2'
-  4: # x-large
+  xlarge:
     vm_attrs:
       cpus:   '2'
       memory: '8589934592'

--- a/foreman_setup.py
+++ b/foreman_setup.py
@@ -8,7 +8,7 @@ from himlarcli import utils as himutils
 # pylint: disable=E1101,E1102
 
 desc = 'Setup compute resources and profiles'
-options = utils.get_options(desc, hosts=False, dry_run=True)
+options = utils.get_options(desc, hosts=False)
 keystone = Keystone(options.config, debug=options.debug)
 logger = keystone.get_logger()
 domain = keystone.get_config('openstack', 'domain')
@@ -33,49 +33,54 @@ for x in range(1, (num_resources+1)):
     resource['url'] = 'qemu+tcp://%s.%s:16509/system' % (name, domain)
     if name not in found_resources:
         logger.debug('=> add new compute resource %s' % name)
-        if not options.dry_run:
-            result = foreman.create_compute_resources(resource)
-            found_resources[name] = result['id']
+        result = foreman.create_compute_resources(resource)
+        found_resources[name] = result['id']
     else:
         logger.debug('=> update compute resource %s' % name)
-        if not options.dry_run:
-            result = foreman.update_compute_resources(found_resources[name], resource)
+        result = foreman.update_compute_resources(found_resources[name], resource)
 
 # Compute profile
 profile_config = himutils.load_config('config/compute_profiles.yaml')
 if keystone.region not in profile_config:
-    compute_attribute = profile_config['default']
+    profiles = profile_config['default']
 else:
-    compute_attribute = profile_config[keystone.region]
+    profiles = profile_config[keystone.region]
 
-for x in range(1, 4):
-    profile = foreman.show_compute_profile(x)
-    for r in found_resources:
-        found_profile = None
-        for attr in profile['compute_attributes']:
-            if r == attr['compute_resource_name']:
-                found_profile = attr
-        if not found_profile:
-            if not options.dry_run:
-                result = foreman.create_compute_attributes(
-                    x,
-                    found_resources[r],
-                    compute_attribute[x])
-                logger.debug("=> create result %s" % result)
-            else:
-                logger.debug('=> dryrun %s(%s): %s' % (r, profile['name'], compute_attribute[x]))
+found_profiles = foreman.get_compute_profiles()
+
+verified_profiles = list()
+
+if found_profiles:
+    for found_profile in found_profiles.keys():
+        if found_profile not in profiles:
+            # We only want profiles defined in config/compute_profiles.yaml
+            logger.debug("=> deleting profile %s" % found_profile)
+            foreman.delete_compute_profile(found_profiles[found_profile])
         else:
-            attr = found_profile
-            if r == attr['compute_resource_name']:
-                if attr['vm_attrs'] == compute_attribute[x]['vm_attrs']:
-                    logger.debug("=> %s: no change for %s" % (profile['name'], r))
-                    continue
-                if not options.dry_run:
+            verified_profiles.append(found_profile)
+
+for profile_name in profiles.keys():
+    if profile_name not in verified_profiles:
+        compute_profile = {'compute_profile': {'name': profile_name}}
+        profile_result = foreman.create_compute_profile(compute_profile)
+        logger.debug("=> create profile result %s" % profile_result)
+        for r in found_resources:
+            attr_result = foreman.create_compute_attributes(
+                profile_result['id'],
+                found_resources[r],
+                profiles[profile_name])
+            logger.debug("=> create attributes result %s" % attr_result)
+    else:
+        ext_profile = foreman.show_compute_profile(found_profiles[profile_name])
+        for attr in ext_profile['compute_attributes']:
+            name = attr['compute_profile_name']
+            if attr['vm_attrs'] == profiles[name]['vm_attrs']:
+                logger.debug("=> no change for %s" % name)
+            else:
+                for r in found_resources:
                     result = foreman.update_compute_attributes(
-                        x,
+                        attr['compute_profile_id'],
                         found_resources[r],
                         attr['id'],
-                        compute_attribute[x])
+                        profiles[name])
                     logger.debug("=> update result %s" % result)
-                else:
-                    logger.debug("=> dryrun %s(%s): %s" % (r, profile['name'], compute_attribute[x]))

--- a/himlarcli/foremanclient.py
+++ b/himlarcli/foremanclient.py
@@ -54,8 +54,8 @@ class ForemanClient(Client):
         resource = '/api/compute_resources'
         resources = self._get(resource, per_page='10000')
         found_resources = dict({})
-        for r in resources['results']:
-            found_resources[r['name']] = r['id']
+        for resource in resources['results']:
+            found_resources[resource['name']] = resource['id']
         return found_resources
 
     def create_compute_resources(self, data):
@@ -78,10 +78,27 @@ class ForemanClient(Client):
         res = self._put(resource, data)
         return res
 
-    def show_compute_profile(self, name):
-        resource = '/api/compute_profiles/%s' % name
+    def get_compute_profiles(self):
+        resource = '/api/compute_profiles'
+        profiles = self._get(resource)
+        found_profiles = dict({})
+        for profile in profiles['results']:
+            found_profiles[profile['name']] = profile['id']
+        return found_profiles
+
+    def create_compute_profile(self, data):
+        resource = '/api/compute_profiles'
+        res = self._post(resource, data)
+        return res
+
+    def show_compute_profile(self, profile_id):
+        resource = '/api/compute_profiles/%s' % profile_id
         res = self._get(resource)
         return res
+
+    def delete_compute_profile(self, profile_id):
+        resource = '/api/compute_profiles/%s' % profile_id
+        res = self._delete(resource)
 
     def get_host(self, host):
         host = self.__set_host(host)


### PR DESCRIPTION
Create profiles from config instead of basing them on defaults and guessing. Note that the compute profile config is now based on names instead of IDs. Also note the new functions in himlarcli's  Foreman client that replaces those in python-foreman.