### PR TITLE
Revert foreman client

### DIFF
--- a/foreman_setup.py
+++ b/foreman_setup.py
@@ -98,7 +98,7 @@ if keystone.region not in resource_config:
 else:
     num_resources = resource_config[keystone.region]['num_resources']
 logger.debug("=> number of compute resources for %s: %s" % (keystone.region, num_resources))
-found_resources = foreman.get_computer_resources()
+found_resources = foreman.get_compute_resources()
 
 for x in range(1, (num_resources+1)):
     name = '%s-controller-0%s' % (keystone.region, x)

--- a/foreman_setup.py
+++ b/foreman_setup.py
@@ -154,7 +154,7 @@ for profile_name in profiles.keys():
                 logger.debug("=> no change for %s" % name)
             else:
                 for r in found_resources:
-                    result = foreman.update_computeattributes(
+                    result = client.update_computeattributes(
                         attr['compute_profile_id'],
                         found_resources[r],
                         attr['id'],

--- a/foreman_setup.py
+++ b/foreman_setup.py
@@ -147,7 +147,7 @@ for profile_name in profiles.keys():
                 profiles[profile_name])
             logger.debug("=> create attributes result %s" % attr_result)
     else:
-        ext_profile = client.show_computeprofile(found_profiles[profile_name])
+        ext_profile = client.show_computeprofiles(found_profiles[profile_name])
         for attr in ext_profile['compute_attributes']:
             name = attr['compute_profile_name']
             if attr['vm_attrs'] == profiles[name]['vm_attrs']:

--- a/foreman_setup.py
+++ b/foreman_setup.py
@@ -7,13 +7,89 @@ from himlarcli import utils as himutils
 # Fix foreman functions and logger not-callable
 # pylint: disable=E1101,E1102
 
-desc = 'Setup compute resources and profiles'
+desc = 'Setup Foreman for himlar'
 options = utils.get_options(desc, hosts=False)
 keystone = Keystone(options.config, debug=options.debug)
 logger = keystone.get_logger()
 domain = keystone.get_config('openstack', 'domain')
 
 foreman = ForemanClient(options.config, options.debug, log=logger)
+client = foreman.get_client()
+
+# create foreman domain based on config
+# get domain id
+
+# get smart proxy id for tftp
+
+# create subnet
+# mgmt network + netmask from config
+# domain_ids = domain_id
+# tftp_ids = proxy_id
+# dns-primary, dns-secondary, gateway is blank
+# get subnet id
+
+# Glabal parameters
+# enable-puppetlabs-repo false
+# enable-puppetlabs-pc1-repo true
+# run-puppet-in-installer true
+# time-zone Europe/Oslo
+# ntp-server no.pool.ntp.org
+# root-pass rootpw_md5
+# entries-per-page 100
+# foreman-url https://
+# unattended-url http://
+# trusted-puppetmaster-hosts <foreman-fqdn>
+# discovery-fact-column ipmi_ipaddress
+# update-ip-from-built-request true
+# use-shortname-for-vms true
+# idle-timeout 180
+#
+# check if we can avoid safemode_render bug, and if so
+# safemode-render true
+
+# medium
+# name CentOS download.iaas.uio.no
+# os-family Redhat
+# path
+# get ids
+
+# sync templates with foreman_templates /api/v2/templates/import
+# get provision_id norcams Kickstart default
+# get pxelinux_id norcams PXELinux
+# get ptable_id norcams ptable default
+
+# associate ptable templates with Redhat
+
+# create and update os
+# Create CentOS major 7 minor 6
+# associate with family Redhat
+# architecture-ids 1
+# medium-ids download.iaas.uio.no
+# ptable norcams ...
+# provision_id + pxelinux_id
+# make ^^ default
+
+# create default env production
+
+# create base hostgroup
+# name base
+# architecture x86_64
+# domain $foreman_domain_id
+# operatingsystem-id $centos_os
+# medium-id $medium_id_2
+# partition-table-id $norcams_ptable_id
+# subnet-id $foreman_subnet_id
+# puppet-proxy-id $foreman_proxy_id
+# puppet-ca-proxy-id $foreman_proxy_id
+# environment production
+
+# create storage hostgroup
+# parent base
+# parameter installdevice <config value>
+
+# create compute hosgroup
+# parent base
+# parameter installdevice <config value>
 
 # Add compute resources
 resource_config = himutils.load_config('config/compute_resources.yaml')
@@ -22,7 +98,7 @@ if keystone.region not in resource_config:
 else:
     num_resources = resource_config[keystone.region]['num_resources']
 logger.debug("=> number of compute resources for %s: %s" % (keystone.region, num_resources))
-found_resources = foreman.get_compute_resources()
+found_resources = foreman.get_computer_resources()
 
 for x in range(1, (num_resources+1)):
     name = '%s-controller-0%s' % (keystone.region, x)
@@ -33,11 +109,11 @@ for x in range(1, (num_resources+1)):
     resource['url'] = 'qemu+tcp://%s.%s:16509/system' % (name, domain)
     if name not in found_resources:
         logger.debug('=> add new compute resource %s' % name)
-        result = foreman.create_compute_resources(resource)
+        result = client.create_computeresources(resource)
         found_resources[name] = result['id']
     else:
         logger.debug('=> update compute resource %s' % name)
-        result = foreman.update_compute_resources(found_resources[name], resource)
+        result = client.update_computeresources(found_resources[name], resource)
 
 # Compute profile
 profile_config = himutils.load_config('config/compute_profiles.yaml')
@@ -55,30 +131,30 @@ if found_profiles:
         if found_profile not in profiles:
             # We only want profiles defined in config/compute_profiles.yaml
             logger.debug("=> deleting profile %s" % found_profile)
-            foreman.delete_compute_profile(found_profiles[found_profile])
+            client.delete_computeprofile(found_profiles[found_profile])
         else:
             verified_profiles.append(found_profile)
 
 for profile_name in profiles.keys():
     if profile_name not in verified_profiles:
         compute_profile = {'compute_profile': {'name': profile_name}}
-        profile_result = foreman.create_compute_profile(compute_profile)
+        profile_result = client.create_computeprofile(compute_profile)
         logger.debug("=> create profile result %s" % profile_result)
         for r in found_resources:
-            attr_result = foreman.create_compute_attributes(
+            attr_result = client.create_computeattributes(
                 profile_result['id'],
                 found_resources[r],
                 profiles[profile_name])
             logger.debug("=> create attributes result %s" % attr_result)
     else:
-        ext_profile = foreman.show_compute_profile(found_profiles[profile_name])
+        ext_profile = client.show_computeprofile(found_profiles[profile_name])
         for attr in ext_profile['compute_attributes']:
             name = attr['compute_profile_name']
             if attr['vm_attrs'] == profiles[name]['vm_attrs']:
                 logger.debug("=> no change for %s" % name)
             else:
                 for r in found_resources:
-                    result = foreman.update_compute_attributes(
+                    result = foreman.update_computeattributes(
                         attr['compute_profile_id'],
                         found_resources[r],
                         attr['id'],

--- a/himlarcli/foremanclient.py
+++ b/himlarcli/foremanclient.py
@@ -1,28 +1,23 @@
 from himlarcli.client import Client
 import sys
 import ConfigParser
-import requests
-import json
+from foreman.client import Foreman
 from himlarcli import utils
 
 class ForemanClient(Client):
 
-    def __init__(self, config_path, debug=False, log=None):
+    def __init__(self, config_path, debug=False, version='1', log=None):
         super(ForemanClient, self).__init__(config_path, debug, log)
-        self.foreman_url = self.get_config('foreman', 'url')
         self.logger.debug('=> config file: %s' % config_path)
-        self.logger.debug('=> foreman url: %s' % self.foreman_url)
+        foreman_url = self.get_config('foreman', 'url')
+        self.logger.debug('=> foreman url: %s' % foreman_url)
         foreman_user = self.get_config('foreman', 'user')
         foreman_password = self.get_config('foreman', 'password')
-        self.api_version = '2'
-        self.session = requests.Session()
-        self.session.auth = (foreman_user, foreman_password)
-        self.session.verify = False
-        self.session.headers.update(
-            {
-                'Accept': 'application/json; version=2',
-                'Content-type': 'application/json'
-            })
+        self.foreman = Foreman(foreman_url,
+                               (foreman_user, foreman_password),
+                               api_version=2,
+                               version=version,
+                               verify=False)
 
     def get_config(self, section, option):
         try:
@@ -48,111 +43,54 @@ class ForemanClient(Client):
         return self.logger
 
     def get_client(self):
-        return self.client
+        return self.foreman
 
     def get_compute_resources(self):
-        resource = '/api/compute_resources'
-        resources = self._get(resource, per_page='10000')
+        resources = self.foreman.index_computeresources()
         found_resources = dict({})
-        for resource in resources['results']:
-            found_resources[resource['name']] = resource['id']
+        for r in resources['results']:
+            found_resources[r['name']] = r['id']
         return found_resources
 
-    def create_compute_resources(self, data):
-        resource = '/api/compute_resources'
-        res = self._post(resource, data)
-        return res
-
-    def update_compute_resources(self, name, data):
-        resource = '/api/compute_resources/%s' % name
-        res = self._put(resource, data)
-        return res
-
-    def create_compute_attributes(self, profile_id, resource_id, data):
-        resource = '/api/compute_profiles/%s/compute_resources/%s/compute_attributes' % (profile_id, resource_id)
-        res = self._post(resource, data)
-        return res
-
-    def update_compute_attributes(self, profile_id, resource_id, attr_id, data):
-        resource = '/api/compute_profiles/%s/compute_resources/%s/compute_attributes/%s' % (profile_id, resource_id, attr_id)
-        res = self._put(resource, data)
-        return res
-
     def get_compute_profiles(self):
-        resource = '/api/compute_profiles'
-        profiles = self._get(resource)
+        profiles = self.foreman.index_computeprofiles()
         found_profiles = dict({})
-        for profile in profiles['results']:
-            found_profiles[profile['name']] = profile['id']
+        for p in profiles['results']:
+            found_profiles[p['name']] = p['id']
         return found_profiles
-
-    def get_profile_id(self, profile_name):
-        resource = '/api/compute_profiles/%s' % profile_name
-        profile = self._get(resource)
-        return profile['id']
-
-    def create_compute_profile(self, data):
-        resource = '/api/compute_profiles'
-        res = self._post(resource, data)
-        return res
-
-    def show_compute_profile(self, profile_id):
-        resource = '/api/compute_profiles/%s' % profile_id
-        res = self._get(resource)
-        return res
-
-    def delete_compute_profile(self, profile_id):
-        resource = '/api/compute_profiles/%s' % profile_id
-        res = self._delete(resource)
 
     def get_host(self, host):
         host = self.__set_host(host)
-        resource = "/api/hosts/%s" % host
-        return self._get(resource)
+        return self.foreman.show_hosts(id=host)
 
     def get_fact(self, host, fact):
         host = self.__set_host(host)
         facts = self.get_facts(host)
-        if facts['results']:
-            fact = facts['results'][host][fact]
-            return fact
-        else:
-            return None
+        fact = facts['results'][host][fact]
+        return fact
 
-    def get_facts(self, host):
+    def get_facts(self, host_id):
+        host = self.__set_host(host_id)
+        return self.foreman.hosts.fact_values_index(host_id=host, per_page=10000)
+
+    def set_host_build(self, host, build=True):
         host = self.__set_host(host)
-        resource = "/api/hosts/%s/facts" % host
-        return self._get(resource, per_page='10000')
-
-    def set_host_build(self, name, build=True):
-        host = dict()
-        host['name'] = self.__set_host(name)
-        host['build'] = build
-        resource = '/api/hosts/%s' % host['name']
-        if len(self.get_host(host['name'])) > 0:
-            self._put(resource, host)
+        if len(self.foreman.show_hosts(id=host)) > 0:
+            self.foreman.update_hosts(id=host, host={'build': build})
 
     def get_hosts(self, search=None):
-        resource = '/api/hosts'
-        return self._get(resource, per_page='10000', search=search)
-
-    def power_on(self, hostname):
-        resource = '/api/hosts/%s/power' % hostname
-        self.logger.debug('=> Power on %s' % hostname)
-        data = {'power_action': 'on'}
-        self._put(resource, data)
+        hosts = self.foreman.index_hosts()
+        self.logger.debug("=> fetch %s page(s) with a total of %s hosts" %
+                          (hosts['page'], hosts['total']))
+        return hosts
 
     def create_host(self, host):
         if 'name' not in host:
             self.logger.debug('host dict missing name')
             return
         self.logger.debug('=> create new host %s' % host['name'])
-        resource = '/api/hosts'
-        res = self._post(resource, host)
-        if type(res) is dict:
-            return res
-        else:
-            return None
+        result = self.foreman.create_host(host)
+        self.logger.debug('=> host created: %s' % result)
 
     def create_node(self, name, node_data, region):
         if self.get_host(name):
@@ -163,10 +101,7 @@ class ForemanClient(Client):
         host['name'] = name
         host['build'] = self.__get_node_data('build', node_data, '1')
         host['hostgroup_id'] = self.__get_node_data('hostgroup', node_data, '1')
-        host['compute_profile_id'] = self.get_profile_id(
-            self.__get_node_data('compute_profile',
-                                 node_data,
-                                 'small'))
+        host['compute_profile_id'] = self.__get_node_data('compute_profile', node_data, '1')
         host['interfaces_attributes'] = self.__get_node_data(
             'interfaces_attributes', node_data, {})
         host['compute_attributes'] = self.__get_node_data(
@@ -185,14 +120,13 @@ class ForemanClient(Client):
         elif 'mac' not in node_data:
             self.logger.debug('=> mac or compute resource are mandatory for %s' % name)
             return
-        print host
         if not self.dry_run:
-            result = self.create_host(host)
+            result = self.foreman.create_hosts(host)
             if not result:
                 self.log_error('Could not create host. Check production.log on foreman host!')
                 return
             if 'mac' not in node_data:
-                self.power_on(result['name'])
+                self.foreman.hosts.power(id=result['name'], power_action='start')
             self.logger.debug('=> create host %s' % result)
         else:
             self.logger.debug('=> dry run: host config %s' % host)
@@ -200,10 +134,9 @@ class ForemanClient(Client):
     def delete_node(self, host):
         host = self.__set_host(host)
         if not self.dry_run:
-            resource = "/api/hosts/%s" % host
-            result = self._delete(resource)
+            result = self.foreman.destroy_hosts(host)
             if not result:
-                self.log_error('=> could not delete node %s' % host)
+                self.log_error('Could not delete host.')
                 return
             self.logger.debug('=> deleted node %s' % host)
         else:
@@ -218,63 +151,6 @@ class ForemanClient(Client):
             self.logger.debug("=> prepend %s to %s" % (domain, host))
             host = host + '.' + domain
         return host
-
-    def _get(self, url, **kwargs):
-        """
-        :param url: relative url to resource
-        :param kwargs: parameters for the api call
-        """
-        res = self.session.get(
-            '%s%s' % (self.foreman_url, url),
-            params=kwargs
-        )
-        return self._process_request_result(res)
-
-    def _post(self, url, data):
-        """
-        :param url: relative url to resource
-        :param data: parameters for the api call
-        """
-        data = json.dumps(data)
-        res = self.session.post(
-            '%s%s' % (self.foreman_url, url),
-            data=data
-        )
-        return self._process_request_result(res)
-
-    def _put(self, url, data):
-        """
-        :param url: relative url to resource
-        :param kwargs: parameters for the api call
-        """
-        data = json.dumps(data)
-        res = self.session.put(
-            '%s%s' % (self.foreman_url, url),
-            data=data
-        )
-        return self._process_request_result(res)
-
-    def _delete(self, url):
-        """
-        :param url: relative url to resource
-        :param kwargs: parameters for the api call
-        """
-        res = self.session.delete(
-            '%s%s' % (self.foreman_url, url),
-        )
-        return self._process_request_result(res)
-
-    def _process_request_result(self, res):
-        if res.status_code < 200 or res.status_code >= 300:
-            if res.status_code == 404:
-                return []
-            elif res.status_code == 406:
-                self.log_error('=> API returned 406: %s' % res)
-            self.log_error('Something went wrong: %s' % res)
-        try:
-            return res.json()
-        except ValueError:
-            return res.text
 
     @staticmethod
     def log_error(msg, code=0):


### PR DESCRIPTION
This should revert the refactoring of the Foreman client in himlarcli, now using python-foreman as before. The foreman_setup script has also been fixed and tested. 