### PR TITLE
Image rewrite

### DIFF
--- a/config/images/cirros.yaml
+++ b/config/images/cirros.yaml
@@ -10,4 +10,4 @@ images:
     'checksum':         'md5'
     'min_ram':          256
     'min_disk':         1
-    'visibility':       'private'
+    'visibility':       'shared'

--- a/config/parser/image.old
+++ b/config/parser/image.old
@@ -1,0 +1,67 @@
+---
+# Use empty value for None
+desc: 'Manage gold images. Use <action> -h for help on each action'
+actions:
+  'list':     'List all active gold images (public)'
+  'update':   'Update images from config file'
+  'usage':    'Check image usage'
+  'purge':    'Delete images'
+  'grant':    'Grant access to private image from project'
+  'test':     'Create instances base on images'
+  'retire':   'Will retire one or more images (deactivate and rename)'
+opt_args:
+  '--region':
+    'dest':     'region'
+    'help':     'override current region'
+  '--domain':
+    'sub':      'grant'
+    'dest':     'domain'
+    'help':     'openstack domain to use'
+    'default':  'Dataporten'
+  '--detailed':
+    'sub':      ['list', 'usage']
+    'dest':     'detailed'
+    'help':     'show detailed list'
+    'action':   'store_const'
+    'const':    true
+    'default':  false
+  '-i':
+    'sub':      [ 'update', 'retire' ]
+    'dest':     'image_config'
+    'help':     'config file under config/images/'
+    'default':  'default.yaml'
+  '-n':
+    'sub':      ['update', 'grant', 'test', 'retire']
+    'dest':     'name'
+    'help':     'only use image with this name (use short name)'
+  '-t':
+    'sub':      ['usage', 'purge', 'list', 'grant', 'test']
+    'dest':     'type'
+    'help':     'image type'
+    'default':  'gold'
+#    'choices':  ['all', 'gold', 'test', 'ipv6']
+  '-p':
+    'sub':      'grant'
+    'dest':     'project'
+    'help':     'project name to grant access to'
+    'required': true
+  '-v':
+    'sub':      ['usage', 'purge', 'list', 'test']
+    'dest':     'visibility'
+    'help':     'image visibility'
+    'default':  'public'
+    'choices':  ['public', 'private', 'shared']
+  '--deactive':
+    'sub':      ['usage', 'purge', 'list']
+    'dest':     'deactive'
+    'help':     'only deactivated images'
+    'action':   'store_const'
+    'const':    true
+    'default':  false
+  '--skip-cleanup':
+    'sub':      [ 'update' ]
+    'dest':     'skip_cleanup'
+    'help':     'skip cleanup of downloaded images'
+    'action':   'store_const'
+    'const':    true
+    'default':  false

--- a/config/parser/image.yaml
+++ b/config/parser/image.yaml
@@ -2,28 +2,20 @@
 # Use empty value for None
 desc: 'Manage images in current region! Use <action> -h for help on each action'
 actions:
-  'list':     'List all images. Output depends on visibility, tags and status'
-  'update':   'Update images from config file'
-  'usage':    'Check image usage. Output depends on visibility, tags and status'
-  'purge':    'Delete unused deactive images'
-  'grant':    'Grant access to a shared image'
-  'revoke':   'Revoke access to a shared image'
-  'list-access': 'List project with access to shared images'
-#  'test':     'Create instances base on images'
-#  'retire':   'Will retire one or more images (deactivate and rename)'
+  'list':         'List all images. Output depends on visibility, tags and status'
+  'update':       'Update images from config file'
+  'usage':        'Check image usage. Output depends on visibility, tags and status'
+  'purge':        'Delete unused deactive images'
+  'grant':        'Grant access to a shared image'
+  'revoke':       'Revoke access to a shared image'
+  'list-access':  'List project with access to shared images'
+
 opt_args:
   '--domain':
     'dest':     'domain'
     'help':     'openstack domain to use'
     'default':  'Dataporten'
     'weight':   60
-  # '--deactive':
-  #   'sub':      ['list', 'usage']
-  #   'dest':     'deactive'
-  #   'help':     'only deactivated images'
-  #   'action':   'store_const'
-  #   'const':    true
-  #   'default':  false
   '--detailed':
     'sub':      ['usage']
     'dest':     'detailed'

--- a/config/parser/image.yaml
+++ b/config/parser/image.yaml
@@ -9,7 +9,7 @@ actions:
   'grant':        'Grant access to a shared image'
   'revoke':       'Revoke access to a shared image'
   'list-access':  'List project with access to shared images'
-
+  'retire':       'Retire manage images. Hint: Move config to retire.yaml and use this as config'
 opt_args:
   '--domain':
     'dest':     'domain'
@@ -31,7 +31,7 @@ opt_args:
     'const':    true
     'default':  false
   '-i':
-    'sub':      ['update']
+    'sub':      ['update', 'retire']
     'dest':     'image_config'
     'help':     'config file under config/images/'
     'default':  'default.yaml'
@@ -53,9 +53,13 @@ opt_args:
     'help':     'image type tag'
     'default':  'all'
   '-n':
-    'sub':      ['list', 'usage', 'purge', 'update', 'grant', 'revoke', 'list-access']
+    'sub':      ['list', 'usage', 'purge', 'grant', 'revoke', 'list-access', 'update']
     'dest':     'name'
     'help':     'image name tag (short name)'
+  'name':
+    'sub':      ['retire']
+    'metavar':  'name'
+    'help':     'Image short name. Must be both in config file and name tag for active image'
   '-p':
     'sub':      ['grant', 'revoke']
     'dest':     'project'

--- a/config/parser/image.yaml
+++ b/config/parser/image.yaml
@@ -1,60 +1,75 @@
 ---
 # Use empty value for None
-desc: 'Manage gold images. Use <action> -h for help on each action'
+desc: 'Manage images in current region! Use <action> -h for help on each action'
 actions:
-  'list':     'List all active gold images (public)'
+  'list':     'List all images. Output depends on visibility, tags and status'
   'update':   'Update images from config file'
-  'usage':    'Check image usage'
-  'purge':    'Delete images'
-  'grant':    'Grant access to private image from project'
-  'test':     'Create instances base on images'
-  'retire':   'Will retire one or more images (deactivate and rename)'
+  'usage':    'Check image usage. Output depends on visibility, tags and status'
+  'purge':    'Delete unused deactive images'
+  'grant':    'Grant access to a shared image'
+  'revoke':   'Revoke access to a shared image'
+  'list-access': 'List project with access to shared images'
+#  'test':     'Create instances base on images'
+#  'retire':   'Will retire one or more images (deactivate and rename)'
 opt_args:
-  '--region':
-    'dest':     'region'
-    'help':     'override current region'
   '--domain':
-    'sub':      'grant'
     'dest':     'domain'
     'help':     'openstack domain to use'
     'default':  'Dataporten'
+    'weight':   60
+  # '--deactive':
+  #   'sub':      ['list', 'usage']
+  #   'dest':     'deactive'
+  #   'help':     'only deactivated images'
+  #   'action':   'store_const'
+  #   'const':    true
+  #   'default':  false
   '--detailed':
-    'sub':      ['list', 'usage']
+    'sub':      ['usage']
     'dest':     'detailed'
     'help':     'show detailed list'
     'action':   'store_const'
     'const':    true
     'default':  false
-  '-i':
-    'sub':      [ 'update', 'retire' ]
-    'dest':     'image_config'
-    'help':     'config file under config/images/'
-    'default':  'default.yaml'
-  '-n':
-    'sub':      ['update', 'grant', 'test', 'retire']
-    'dest':     'name'
-    'help':     'only use image with this name (use short name)'
-  '-t':
-    'sub':      ['usage', 'purge', 'list', 'grant', 'test']
-    'dest':     'type'
-    'help':     'image type'
-    'default':  'gold'
-#    'choices':  ['all', 'gold', 'test', 'ipv6']
-  '-p':
-    'sub':      'grant'
-    'dest':     'project'
-    'help':     'project name to grant access to'
-    'required': true
-  '-v':
-    'sub':      ['usage', 'purge', 'list', 'test']
-    'dest':     'visibility'
-    'help':     'image visibility'
-    'default':  'public'
-    'choices':  ['public', 'private']
-  '--deactive':
-    'sub':      ['usage', 'purge', 'list']
-    'dest':     'deactive'
-    'help':     'only deactivated images'
+  '--skip-cleanup':
+    'sub':      ['update']
+    'dest':     'skip_cleanup'
+    'help':     'skip cleanup of downloaded images'
     'action':   'store_const'
     'const':    true
     'default':  false
+  '-i':
+    'sub':      ['update']
+    'dest':     'image_config'
+    'help':     'config file under config/images/'
+    'default':  'default.yaml'
+  '-s':
+    'sub':      ['list', 'usage']
+    'dest':     'status'
+    'help':     'image status'
+    'default':  'active'
+    'choices':  ['acitve', 'deactive']
+  '-v':
+    'sub':      ['list', 'usage', 'purge']
+    'dest':     'visibility'
+    'help':     'image visibility'
+    'default':  'public'
+    'choices':  ['public', 'private', 'shared']
+  '-t':
+    'sub':      ['list', 'usage', 'purge', 'grant', 'revoke', 'list-access']
+    'dest':     'type'
+    'help':     'image type tag'
+    'default':  'all'
+  '-n':
+    'sub':      ['list', 'usage', 'purge', 'update', 'grant', 'revoke', 'list-access']
+    'dest':     'name'
+    'help':     'image name tag (short name)'
+  '-p':
+    'sub':      ['grant', 'revoke']
+    'dest':     'project'
+    'help':     'project name to grant image access'
+    'required': true
+  '--limit':
+    'sub':      ['purge']
+    'dest':     'limit'
+    'help':     'limit number of deleted images'

--- a/himlarcli/glance.py
+++ b/himlarcli/glance.py
@@ -2,7 +2,6 @@ import itertools
 from himlarcli.client import Client
 from glanceclient import Client as glclient
 from glanceclient import exc
-import sys
 
 class Glance(Client):
 
@@ -34,10 +33,12 @@ class Glance(Client):
             self.log_error('Image with ID %s not found!' % image_id)
         return image
 
-    """ Get images.
-    To filter use filters dict with key value pairs.
-    E.G. get_images(filters={'key': 'value'}) """
     def get_images(self, **kwargs):
+        """
+            Get images.
+            To filter use filters dict with key value pairs.
+            E.G. get_images(filters={'key': 'value'})
+        """
         return self.client.images.list(**kwargs)
 
     def find_image(self, **kwargs):
@@ -48,7 +49,7 @@ class Glance(Client):
         try:
             images = list(result) if result else list()
             return images
-        except exc.HTTPServiceUnavailable as e:
+        except exc.HTTPServiceUnavailable:
             self.log_error('Glance: Service Unavailable')
         return list()
 
@@ -67,10 +68,19 @@ class Glance(Client):
         return None
 
     def create_image(self, source_path, **kwargs):
-        self.logger.debug('=> create new image %s' % kwargs['name'])
-        self.image = self.client.images.create(**kwargs)
-        self.upload_image(source_path)
-        return self.image
+        if 'name' not in kwargs:
+            self.log_error('image name missing!')
+            return None
+        self.debug_log('create new image {}'.format(kwargs['name']))
+        try:
+            if not self.dry_run:
+                image = self.client.images.create(**kwargs)
+        except exc.HTTPServiceUnavailable as e:
+            self.log_error(e)
+        if image:
+            self.__upload_image(source_path, image)
+            return image
+        return None
 
     def delete_private_images(self, project_id):
         images = self.find_image(filters={'owner': project_id})
@@ -78,29 +88,62 @@ class Glance(Client):
             self.delete_image(image.id)
 
     def delete_image(self, image_id):
-        if not self.image and not image_id:
-            self.logger.critical('Image must exist before deletion.')
+        if not self.get_image_by_id(image_id):
+            self.debug_log('deletion failed! not fond: {}'.format(image_id))
             return
-        if not image_id:
-            image_id = self.image.id
-        self.debug_log('image delete %s' % image_id)
+        self.debug_log('delete image id {}'.format(image_id))
         try:
             if not self.dry_run:
                 self.client.images.delete(image_id)
         except exc.HTTPServiceUnavailable as e:
             self.log_error(e)
 
-    def update_image(self, name, image_id=None, **kwargs):
-        if not self.image and not image_id:
-            self.logger.debug('=> image not found %s' % name)
-            if name:
-                self.get_image(name)
-            else:
-                self.logger.critical('Image must exist before upload.')
-                sys.exit(1)
-        if not image_id:
-            image_id = self.image.id
-        self.client.images.update(image_id=image_id, name=name, **kwargs)
+    def update_image(self, name, image_id, **kwargs):
+        if not self.get_image_by_id(image_id):
+            self.debug_log('image not fond: {}'.format(name))
+            return
+        try:
+            if not self.dry_run:
+                self.client.images.update(image_id=image_id, name=name, **kwargs)
+        except exc.HTTPServiceUnavailable as e:
+            self.log_error(e)
+
+    def get_image_access(self, image_id):
+        try:
+            members = self.client.image_members.list(image_id)
+        except exc.HTTPServiceUnavailable as e:
+            self.log_error(e)
+        return members
+
+    def set_image_access(self, image_id, project_id, action='grant'):
+        if action not in ['grant', 'revoke']:
+            self.debug_log('unknown image access action: {}'.format(action))
+            return
+
+        if action == 'grant':
+            if self.__get_project_image_member(image_id, project_id):
+                self.debug_log(('membership exsist: dropping grant for project '
+                    + '{} on image {}').format(project_id, image_id))
+                return
+            if not self.dry_run:
+                try:
+                    self.client.image_members.create(image_id, project_id)
+                    self.client.image_members.update(image_id, project_id, 'accepted')
+                except exc.HTTPServiceUnavailable as e:
+                    self.log_error(e)
+            self.debug_log('grant access to project {} for image {}'.
+                           format(project_id, image_id))
+        elif action == 'revoke':
+            if not self.__get_project_image_member(image_id, project_id):
+                return
+            if not self.dry_run:
+                try:
+                    self.client.image_members.delete(image_id, project_id)
+                except exc.HTTPServiceUnavailable as e:
+                    self.log_error(e)
+            self.debug_log('revoke access to project {} for image {}'.
+                           format(project_id, image_id))
+
 
     def set_access(self, image_id, project_id, action='create'):
         if action not in ['create', 'delete']:
@@ -129,41 +172,36 @@ class Glance(Client):
     def get_access(self, image_id):
         return self.client.image_members.list(image_id)
 
-    def deactivate(self, name=None, image_id=None):
-        if not self.image and not image_id:
-            self.logger.debug('=> image not found %s' % name)
-            if name:
-                self.get_image(name)
-            else:
-                self.logger.critical('Image must exist to deactivate.')
-                sys.exit(1)
-        if not image_id:
-            image_id = self.image.id
-        self.client.images.deactivate(image_id)
-        self.logger.debug('=> deactivate image id %s' % image_id)
+    def deactivate(self, image_id):
+        if not self.get_image_by_id(image_id):
+            self.debug_log('deactivation failed! not fond: {}'.format(image_id))
+            return
+        self.debug_log('deactivate image id {}'.format(image_id))
+        try:
+            if not self.dry_run:
+                self.client.images.deactivate(image_id)
+        except exc.HTTPServiceUnavailable as e:
+            self.log_error(e)
 
     def reactivate(self, image_id):
+        if not self.get_image_by_id(image_id):
+            self.debug_log('reactiation failed! not fond: {}'.format(image_id))
+            return
+        self.debug_log('reactivate image id {}'.format(image_id))
         try:
-            self.logger.debug('=> reactivate image id %s' % image_id)
-            self.client.images.reactivate(image_id)
-        except exc.HTTPNotFound:
-            self.logger.error('=> image id %s not found' % image_id)
+            if not self.dry_run:
+                self.client.images.reactivate(image_id)
+        except exc.HTTPServiceUnavailable as e:
+            self.log_error(e)
 
-    def upload_image(self, source_path, name=None):
-        if not self.image:
-            self.logger.debug('=> image not found %s' % name)
-            if name:
-                self.get_image(name)
-            else:
-                self.logger.critical('Image must exist before upload.')
-                sys.exit(1)
+    def __upload_image(self, source_path, image):
         try:
-            self.client.images.upload(self.image.id, open(source_path, 'rb'))
-            self.logger.debug('=> upload new image %s' % source_path)
+            if not self.dry_run:
+                self.client.images.upload(image.id, open(source_path, 'rb'))
+            self.debug_log('upload new image %s' % source_path)
         except BaseException as e:
             print e
-            self.logger.critical('Upload of %s failed' % self.image.name)
-            sys.exit(1)
+            self.log_error('Upload of {} failed'.format(image.name), 1)
 
     @staticmethod
     def find_optimal_flavor(image, flavors):
@@ -172,6 +210,13 @@ class Glance(Client):
             if flavor.ram >= image['min_ram'] and flavor.disk >= image['min_disk']:
                 return flavor
         return None
+
+    def __get_project_image_member(self, image_id, project_id):
+        members = self.client.image_members.list(image_id)
+        for member in members:
+            if member.member_id == project_id:
+                return True
+        return False
 
     def __get_images(self):
         self.images = self.client.images.list()

--- a/himlarcli/glance.py
+++ b/himlarcli/glance.py
@@ -72,6 +72,7 @@ class Glance(Client):
             self.log_error('image name missing!')
             return None
         self.debug_log('create new image {}'.format(kwargs['name']))
+        image = None
         try:
             if not self.dry_run:
                 image = self.client.images.create(**kwargs)

--- a/himlarcli/glance.py
+++ b/himlarcli/glance.py
@@ -105,6 +105,9 @@ class Glance(Client):
         try:
             if not self.dry_run:
                 self.client.images.update(image_id=image_id, name=name, **kwargs)
+            updated_data = dict(kwargs)
+            updated_data['name'] = name
+            self.debug_log('update image: {}'.format(updated_data))
         except exc.HTTPServiceUnavailable as e:
             self.log_error(e)
 

--- a/image.old
+++ b/image.old
@@ -1,0 +1,407 @@
+#!/usr/bin/env python
+
+""" Manage images """
+
+import sys
+import os
+import time
+from IPy import IP
+from datetime import datetime
+from himlarcli import utils as himutils
+from himlarcli.keystone import Keystone
+from himlarcli.glance import Glance
+from himlarcli.nova import Nova
+from himlarcli.neutron import Neutron
+from himlarcli.parser import Parser
+from himlarcli.printer import Printer
+
+himutils.is_virtual_env()
+
+# Load parser config from config/parser/*
+parser = Parser()
+options = parser.parse_args()
+printer = Printer(options.format)
+glclient = Glance(options.config, debug=options.debug, region=options.region)
+logger = glclient.get_logger()
+kc = himutils.get_client(Keystone, options, logger, options.region)
+
+# Filters
+tags = list()
+if hasattr(options, 'type'):
+    if options.type != 'all':
+        tags.append(options.type)
+
+def action_grant():
+    project = kc.get_project_by_name(options.project)
+    if not project:
+        himutils.sys_error('Unknown project {}'.format(options.project))
+
+    if options.name:
+        tags.append(options.name)
+    filters = {'status': 'active', 'tag': tags, 'visibility': 'shared'}
+    kc.debug_log('filter: {}'.format(filters))
+    images = glclient.get_images(filters=filters)
+    for image in images:
+        print image
+    # print "WARNING: this will break with the upgrade to ocata"
+    # print "https://trello.com/c/vjRI4EKC/"
+    # ksclient = Keystone(options.config, debug=options.debug, log=logger)
+    # project = ksclient.get_project(project=options.project, domain=options.domain)
+    # if not project:
+    #     himutils.sys_error('Unknown project %s in domain %s' %
+    #                        (options.project, options.domain))
+    # if options.name:
+    #     tags.append(options.name)
+    # filters = {'status': 'active', 'tag': tags, 'visibility': 'private'}
+    # logger.debug('=> filter: %s' % filters)
+    # images = glclient.get_images(filters=filters)
+    # for image in images:
+    #     log_msg = 'grant access to %s from %s' % (image.name, project.name)
+    #     if not options.dry_run:
+    #         glclient.set_access(image.id, project.id)
+    #     else:
+    #         log_msg = 'DRY-RUN: %s' % log_msg
+    #     logger.debug('=> %s' % log_msg)
+
+def action_purge():
+    if not himutils.confirm_action('Purge unused images'):
+        return
+    images = image_usage()
+    for image in images.itervalues():
+        if image['count'] > 0:
+            logger.debug('=> no purge: image %s in use!' % image['name'])
+            continue
+        log_msg = "delete image %s" % image['name']
+        if not options.dry_run:
+            glclient.delete_image(image['id'])
+        else:
+            log_msg = "DRY-RUN: %s" % log_msg
+        logger.debug('=> %s', log_msg)
+
+def action_usage():
+    output = image_usage(options.detailed)
+    out_image = {'header': 'Images with usage count'}
+    printer.output_dict(out_image)
+    distros = {'fedora': 0, 'centos': 0, 'ubuntu': 0, 'debian': 0, 'cirros': 0, 'windows': 0}
+    distros['header'] = 'Distros'
+    tags = dict()
+    tags['header'] = 'Tags'
+    for image in output.itervalues():
+        out_image = {
+            'name': image['name'],
+            'id': image['id'],
+            'count': image['count']}
+        if options.detailed:
+            out_image['instances'] = image['instances']
+            out_image['created_at'] = image['created_at']
+        one_line = False if options.detailed else True
+        printer.output_dict(out_image, sort=True, one_line=one_line)
+        for distro in distros.iterkeys():
+            if distro in image['name'].lower():
+                for tag in image['tags']:
+                    tags[tag] = tags.get(tag, 0) + image['count']
+                distros[distro] += image['count']
+                continue
+    printer.output_dict(distros)
+    printer.output_dict(tags)
+    return output
+
+def action_retire():
+    image_templates = himutils.load_config('config/images/%s' % options.image_config)
+    if not image_templates or 'images' not in image_templates or 'type' not in image_templates:
+        sys.stderr.write("Invalid yaml file (config/images/%s): images hash not found\n"
+                         % options.image_config)
+        sys.exit(1)
+    image_type = image_templates['type']
+    image_msg = options.name if options.name else 'all'
+    question = "Retire all active images matching '%s'" % image_msg
+    if not himutils.confirm_action(question):
+        return
+    found = False
+    for name, image_data in image_templates['images'].iteritems():
+        if options.name and name != options.name:
+            logger.debug('=> dropped %s: image name spesified', name)
+            continue
+        tags = list()
+        tags.append(image_type)
+        tags.append(name)
+        filters = {'tag': tags, 'status': 'active'}
+        logger.debug('=> filter: %s' % filters)
+        images = glclient.find_image(filters=filters, limit=1)
+        if images and len(images) > 0:
+            if not options.dry_run:
+                timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
+                glclient.update_image(image_id=images[0]['id'],
+                                      name=image_data['depricated'],
+                                      depricated=timestamp)
+                glclient.deactivate(image_id=images[0]['id'])
+        found = True
+    if not found:
+        print 'No image found in %s' % options.image_config
+
+def action_list():
+    ksclient = Keystone(options.config, debug=options.debug, log=logger)
+    status = 'deactivated' if options.deactive else 'active'
+    filters = {'status': status, 'visibility': options.visibility, 'tag': tags}
+    logger.debug('=> filter: %s' % filters)
+    images = glclient.get_images(filters=filters)
+    out_image = {'header': 'Image list (id, name, created_at)'}
+    if options.format == 'text':
+        printer.output_dict(out_image)
+    count = 0
+    for image in images:
+        out_image = {'name': image.name, 'created': image.created_at, 'id': image.id}
+        if options.detailed and image.visibility == 'private':
+            access = glclient.get_access(image.id)
+            if access:
+                access_list = list()
+                for member in access:
+                    project = ksclient.get_by_id('project', member['member_id'])
+                    if project:
+                        access_list.append(project.name)
+                out_image['projects'] = access_list
+        if options.detailed and hasattr(image, 'depricated'):
+            out_image['depricated'] = image.depricated
+        if options.detailed:
+            out_image['tags'] = image.tags
+        one_line = False if options.detailed else True
+        printer.output_dict(out_image, sort=True, one_line=one_line)
+        count += 1
+    out_image = {'header': 'Image count', 'count': count}
+    printer.output_dict(out_image)
+
+def action_update():
+    image_templates = himutils.load_config('config/images/%s' % options.image_config)
+    if not image_templates or 'images' not in image_templates or 'type' not in image_templates:
+        sys.stderr.write("Invalid yaml file (config/images/%s): images hash not found\n"
+                         % options.image_config)
+        sys.exit(1)
+    image_type = image_templates['type']
+    for name, image_data in image_templates['images'].iteritems():
+        if options.name and name != options.name:
+            logger.debug('=> dropped %s: image name spesified', name)
+            continue
+        mandatory = ['latest', 'url', 'name', 'min_ram', 'min_disk', 'depricated']
+        if not bool(all(k in image_data for k in mandatory)):
+            logger.debug('=> missing attributes in image hash for %s' % name)
+            continue
+        update_image(name, image_data, image_type)
+
+def image_usage(detailed=False):
+    status = 'deactivated' if options.deactive else 'active'
+    novaclient = Nova(options.config, debug=options.debug, log=logger, region=options.region)
+    filters = {'status': status, 'visibility': options.visibility, 'tag': tags}
+    logger.debug('=> filter: %s' % filters)
+    image_usage = dict()
+    images = glclient.get_images(limit=1000, page_size=999, filters=filters)
+    for image in images:
+        image_usage[image.id] = image
+        image_usage[image.id]['count'] = 0
+        search_opts = {'image': image.id}
+        instances = novaclient.get_all_instances(search_opts=search_opts)
+        if detailed:
+            image_usage[image.id]['instances'] = list()
+        for i in instances:
+            image_usage[image.id]['count'] += 1
+            if detailed:
+                image_usage[image.id]['instances'].append(i.id)
+    return image_usage
+
+def update_image(name, image_data, image_type):
+    if 'checksum' in image_data and 'checksum_file' in image_data:
+        checksum_url = "%s%s" % (image_data['url'], image_data['checksum_file'])
+        checksum_type = image_data['checksum']
+    else:
+        checksum_type = checksum_url = None
+    url = (image_data['url'] + image_data['latest'])
+    imagefile = himutils.download_file(image_data['latest'], url, logger,
+                                       checksum_type, checksum_url, 10000)
+    if not imagefile: # if download or checksum failed
+        logger.debug('=> download %s failed' % url)
+        return
+    #tags = list(image_data['tags']) if 'tags' in image_data else list()
+    tags = list()
+    tags.append(image_type)
+    tags.append(name)
+    # Filter based on tags: type and name (only one of each type should exists)
+    filters = {'tag': tags, 'status': 'active'}
+    logger.debug('=> filter: %s' % filters)
+    images = glclient.find_image(filters=filters, limit=1)
+    if images and len(images) == 1:
+        logger.debug('=> image %s found' % name)
+        checksum = himutils.checksum_file(imagefile, 'md5')
+        if checksum != images[0]['checksum']:
+            logger.debug('=> update image: new checksum found %s' % checksum)
+            result = create_image(name, imagefile, image_data, image_type)
+            if not options.dry_run:
+                timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
+                glclient.update_image(image_id=images[0]['id'],
+                                      name=image_data['depricated'],
+                                      depricated=timestamp)
+                glclient.deactivate(image_id=images[0]['id'])
+        else:
+            result = None
+            logger.debug('=> no new image needed: checksum match found')
+    else:
+        logger.debug('=> image %s not found' % name)
+        result = create_image(name, imagefile, image_data, image_type)
+    if result:
+        logger.debug('=> %s' % result)
+
+    # Cleanup
+    if not options.skip_cleanup and os.path.isfile(imagefile):
+        os.remove(imagefile)
+
+def create_image(name, source_path, image, image_type):
+    # Populate input with default values if not defined in config
+    visibility = image['visibility'] if 'visibility' in image else 'private'
+    disk_format = image['disk_format'] if 'disk_format' in image else 'qcow2'
+    container_format = image['container_format'] if 'container_format' in image else 'bare'
+    # Properties hash from yaml
+    properties = {}
+    if 'properties' in image:
+        for key, value in image['properties'].iteritems():
+            properties[key] = value
+    tags = list()
+    # Tag all images with type and name
+    tags.append(image_type)
+    tags.append(name)
+    if 'tags' in image:
+        for tag in image['tags']:
+            tags.append(tag)
+    # Set image owner
+    if 'owner' in image:
+        project = kc.get_project_by_name(image['owner'])
+        if not project:
+            himutils.log_error('project {} not found!'.format(image['owner']), 0)
+            image_owner = None
+        else:
+            image_owner = project.id
+    else:
+        image_owner = None # no owner is set
+
+    log_msg = "create new image %s" % image['name']
+    if not options.dry_run:
+        result = glclient.create_image(source_path,
+                                       name=image['name'],
+                                       visibility=visibility,
+                                       disk_format=disk_format,
+                                       min_disk=image['min_disk'],
+                                       min_ram=image['min_ram'],
+                                       container_format=container_format,
+                                       tags=tags,
+                                       owner=image_owner,
+                                       **properties)
+    else:
+        log_msg = 'DRY-RUN: ' + log_msg
+        result = None
+    logger.debug('=> %s' % log_msg)
+    return result
+
+def action_test():
+    novaclient = Nova(options.config, debug=options.debug, log=logger, region=options.region)
+    neutronclient = Neutron(options.config, debug=options.debug, log=logger, region=options.region)
+    filters = {'status': 'active', 'visibility': options.visibility, 'tag': tags}
+    logger.debug('=> filter: %s' % filters)
+    images = glclient.get_images(filters=filters)
+    flavors = novaclient.get_flavors('m1')
+    networks = neutronclient.list_networks()
+    secgroup_name = 'image_test-' + str(int(time.time()))
+    secgroup = neutronclient.create_security_port_group(secgroup_name, 22)
+    tests = dict({'passed': 0, 'failed': 0, 'dropped': 0})
+    for image in images:
+        if options.name and options.name not in image.tags:
+            logger.debug('=> dropped: image name %s not in tags %s', options.name,
+                         ', '.join(image.tags))
+            continue
+        for network in networks:
+            if network['name'] == 'imagebuilder':
+                continue
+            try:
+                starttime = int(time.time())
+                print '* Create instance from %s with network %s' % (image.name, network['name'])
+                flavor = glclient.find_optimal_flavor(image, flavors)
+                if not flavor:
+                    print '* Could not optimal find flavor for %s' % image.name
+                    print '-------------------------------------------------------------'
+                    continue
+                logger.debug('=> use %s flavor' % flavor.name)
+                nics = list()
+                nics.append({'net-id': network['id']})
+                server = novaclient.create_server(name='image_test'+ str(int(time.time())),
+                                                  flavor=flavor,
+                                                  image_id=image.id,
+                                                  security_groups=[secgroup['id']],
+                                                  nics=nics)
+                timeout = 300 # 5 min timeout
+                if not server:
+                    print '-------------------------------------------------------------'
+                    continue
+                server = novaclient.get_instance(server.id)
+                while timeout > 0 and server.status == 'BUILD':
+                    time.sleep(2)
+                    timeout -= 2
+                    server = novaclient.get_instance(server.id)
+                if timeout <= 0:
+                    print ('* Could not start instance from image %s in %s seconds' %
+                           (image.name, timeout))
+                if server.status == 'ERROR':
+                    print '* Instance started with error'
+                    print server.fault
+                else:
+                    used_time = int(time.time()) - starttime
+                    print '* Instance started after %s sec' % used_time
+                if server.addresses:
+                    for net in server.addresses[network['name']]:
+                        starttime = int(time.time())
+                        ip = IP(net['addr'])
+                        print ('* Instance started with IPv%s %s (%s)' %
+                               (net['version'], ip, ip.iptype()))
+                        if ip.iptype() == 'ALLOCATED RIPE NCC':
+                            print '* Drop connection check for IPv6 for now'
+                            tests['dropped'] += 1
+                            continue
+                        elif ip.iptype() == 'PRIVATE':
+                            print '* Drop connection check for rfc1918 address for now'
+                            tests['dropped'] += 1
+                            continue
+                        timeout = 90
+                        port = False
+                        while timeout > 0 and not port:
+                            start = int(time.time())
+                            port = himutils.check_port(address=str(ip), port=22, timeout=2, log=logger)
+                            time.sleep(3)
+                            timeout -= (int(time.time()) - start)
+                        used_time = int(time.time()) - starttime
+                        if port:
+                            print '* Port 22 open on %s (%s)' % (ip, ip.iptype())
+                            tests['passed'] += 1
+                        else:
+                            print ('* Unable to reach port 22 on %s after %s sec (%s)'
+                                   % (ip, used_time, ip.iptype()))
+                            tests['failed'] += 1
+                else:
+                    print '* No IP found for instances %s' % server.name
+                try:
+                    server.delete()
+                    time.sleep(3)
+                    print '* Instance deleted'
+                except:
+                    himutils.sys_error('error!!!')
+                print '-------------------------------------------------------------'
+            except KeyboardInterrupt:
+                if server:
+                    server.delete()
+                    time.sleep(5)
+                    print '* Instance deleted'
+    print '* Delete security group'
+    neutronclient.delete_security_group(secgroup['id'])
+    printer.output_dict({'header': 'Result'})
+    printer.output_dict(tests)
+
+# Run local function with the same name as the action
+action = locals().get('action_' + options.action)
+if not action:
+    logger.error("Function action_%s not implemented" % options.action)
+    sys.exit(1)
+action()

--- a/image.py
+++ b/image.py
@@ -126,7 +126,7 @@ def action_purge():
     images = get_image_usage()
     count = 0
     printer.output_dict({'header': 'Images deleted'})
-    limit = options.limit
+    limit = int(options.limit) if options.limit else options.limit
     for image in images.itervalues():
         if image['count'] > 0:
             kc.debug_log('no purge: image {} in use!'.format(image['name']))
@@ -140,7 +140,7 @@ def action_purge():
         printer.output_dict(out_image, sort=True, one_line=True)
         count += 1
         # break purging if limit reached
-        if limit and int(limit) >= count:
+        if limit and count >= int(limit):
             kc.debug_log('limit of {} reached'.format(limit))
             break
     printer.output_dict({'header': 'Image count', 'count': count})

--- a/image.py
+++ b/image.py
@@ -1,79 +1,101 @@
 #!/usr/bin/env python
 
-""" Manage images """
+from himlarcli import tests as tests
+tests.is_virtual_env()
 
-import sys
 import os
-import time
-from IPy import IP
 from datetime import datetime
-from himlarcli import utils as himutils
 from himlarcli.keystone import Keystone
-from himlarcli.glance import Glance
 from himlarcli.nova import Nova
-from himlarcli.neutron import Neutron
+from himlarcli.glance import Glance
 from himlarcli.parser import Parser
 from himlarcli.printer import Printer
+from himlarcli import utils as utils
 
-himutils.is_virtual_env()
-
-# Load parser config from config/parser/*
 parser = Parser()
 options = parser.parse_args()
 printer = Printer(options.format)
-glclient = Glance(options.config, debug=options.debug, region=options.region)
-logger = glclient.get_logger()
 
-# Filters
-tags = list()
-if hasattr(options, 'type'):
-    if options.type != 'all':
-        tags.append(options.type)
+kc = Keystone(options.config, debug=options.debug)
+kc.set_domain(options.domain)
+kc.set_dry_run(options.dry_run)
+logger = kc.get_logger()
+
+gc = utils.get_client(Glance, options, logger)
+
+# Distro list
+distros = {'fedora': 0, 'centos': 0, 'ubuntu': 0, 'debian': 0, 'cirros': 0, 'windows': 0}
+
+# Mandatory image attributes
+mandatory = ['latest', 'url', 'name', 'min_ram', 'min_disk', 'depricated']
 
 def action_grant():
-    print "WARNING: this will break with the upgrade to ocata"
-    print "https://trello.com/c/vjRI4EKC/"
-    ksclient = Keystone(options.config, debug=options.debug, log=logger)
-    project = ksclient.get_project(project=options.project, domain=options.domain)
-    if not project:
-        himutils.sys_error('Unknown project %s in domain %s' %
-                           (options.project, options.domain))
-    if options.name:
-        tags.append(options.name)
-    filters = {'status': 'active', 'tag': tags, 'visibility': 'private'}
-    logger.debug('=> filter: %s' % filters)
-    images = glclient.get_images(filters=filters)
-    for image in images:
-        log_msg = 'grant access to %s from %s' % (image.name, project.name)
-        if not options.dry_run:
-            glclient.set_access(image.id, project.id)
-        else:
-            log_msg = 'DRY-RUN: %s' % log_msg
-        logger.debug('=> %s' % log_msg)
+    set_access('grant')
 
-def action_purge():
-    if not himutils.confirm_action('Purge unused images'):
+def action_revoke():
+    set_access('revoke')
+
+def set_access(action):
+    project = kc.get_project_by_name(options.project)
+    if not project:
+        utils.sys_error('Unknown project {}'.format(options.project))
+    # Grant based on tags, name or type
+    tags = get_tags(names=True)
+    tag_str = 'all tags' if not tags else '[' + ', '.join(tags) + ']'
+    if not utils.confirm_action('{} access to shared images matching {}'
+            .format(action.capitalize(), tag_str)):
         return
-    images = image_usage()
-    for image in images.itervalues():
-        if image['count'] > 0:
-            logger.debug('=> no purge: image %s in use!' % image['name'])
-            continue
-        log_msg = "delete image %s" % image['name']
-        if not options.dry_run:
-            glclient.delete_image(image['id'])
-        else:
-            log_msg = "DRY-RUN: %s" % log_msg
-        logger.debug('=> %s', log_msg)
+    filters = {'status': 'active', 'tag': tags, 'visibility': 'shared'}
+    kc.debug_log('filter: {}'.format(filters))
+    images = gc.get_images(filters=filters)
+    for image in images:
+        gc.set_image_access(image_id=image.id, project_id=project.id, action=action)
+        print('{} access to image {} for project {}'.
+                format(action.capitalize(), image.name, options.project))
+
+def action_list_access():
+    tags = get_tags(names=True)
+    filters = {'status': 'active', 'visibility': 'shared', 'tag': tags}
+    kc.debug_log('filter: {}'.format(filters))
+    images = gc.get_images(filters=filters)
+    for image in images:
+        out_image = image.copy()
+        out_image['members'] = list()
+        members = gc.get_image_access(image.id)
+        printer.output_dict({'header': 'Members of {}'.format(image.name)})
+        for member in members:
+            member_out = {
+                'project': kc.get_by_id('project', member.member_id).name,
+                'status': member.status
+            }
+            printer.output_dict(member_out, one_line=True)
+
+def action_list():
+    status = 'deactivated' if options.status == 'deactive' else 'active'
+    tags = get_tags(names=True)
+    filters = {'status': status, 'visibility': options.visibility, 'tag': tags}
+    kc.debug_log('filter: {}'.format(filters))
+    images = gc.get_images(filters=filters)
+    printer.output_dict({'header': 'Image list (id, created_at, tags)'})
+    count = 0
+    for image in images:
+        out_image = {
+            '1': image.id,
+            '2': image.created_at,
+            '3': '[' + ', '.join(image.tags) + ']'
+        }
+        printer.output_dict(out_image, sort=True, one_line=True)
+        count += 1
+    out_image = {'header': 'Image count', 'count': count}
+    printer.output_dict(out_image)
 
 def action_usage():
-    output = image_usage(options.detailed)
+    output = get_image_usage(options.detailed)
     out_image = {'header': 'Images with usage count'}
     printer.output_dict(out_image)
-    distros = {'fedora': 0, 'centos': 0, 'ubuntu': 0, 'debian': 0, 'cirros': 0, 'windows': 0}
     distros['header'] = 'Distros'
-    tags = dict()
-    tags['header'] = 'Tags'
+    tag_count = dict()
+    tag_count['header'] = 'Tags'
     for image in output.itervalues():
         out_image = {
             'name': image['name'],
@@ -82,111 +104,80 @@ def action_usage():
         if options.detailed:
             out_image['instances'] = image['instances']
             out_image['created_at'] = image['created_at']
+            out_image['tags'] = image['tags']
         one_line = False if options.detailed else True
         printer.output_dict(out_image, sort=True, one_line=one_line)
         for distro in distros.iterkeys():
             if distro in image['name'].lower():
                 for tag in image['tags']:
-                    tags[tag] = tags.get(tag, 0) + image['count']
+                    tag_count[tag] = tag_count.get(tag, 0) + image['count']
                 distros[distro] += image['count']
                 continue
     printer.output_dict(distros)
-    printer.output_dict(tags)
+    printer.output_dict(tag_count)
     return output
 
-def action_retire():
-    image_templates = himutils.load_config('config/images/%s' % options.image_config)
-    if not image_templates or 'images' not in image_templates or 'type' not in image_templates:
-        sys.stderr.write("Invalid yaml file (config/images/%s): images hash not found\n"
-                         % options.image_config)
-        sys.exit(1)
-    image_type = image_templates['type']
-    image_msg = options.name if options.name else 'all'
-    question = "Retire all active images matching '%s'" % image_msg
-    if not himutils.confirm_action(question):
+def action_purge():
+    tags = get_tags(names=True)
+    tag_str = 'all tags' if not tags else '[' + ', '.join(tags) + ']'
+    if not utils.confirm_action('Purge unused {} deactive images matching {}'
+            .format(options.visibility, tag_str)):
         return
-    found = False
-    for name, image_data in image_templates['images'].iteritems():
-        if options.name and name != options.name:
-            logger.debug('=> dropped %s: image name spesified', name)
-            continue
-        tags = list()
-        tags.append(image_type)
-        tags.append(name)
-        filters = {'tag': tags, 'status': 'active'}
-        logger.debug('=> filter: %s' % filters)
-        images = glclient.find_image(filters=filters, limit=1)
-        if images and len(images) > 0:
-            if not options.dry_run:
-                timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
-                glclient.update_image(image_id=images[0]['id'],
-                                      name=image_data['depricated'],
-                                      depricated=timestamp)
-                glclient.deactivate(image_id=images[0]['id'])
-        found = True
-    if not found:
-        print 'No image found in %s' % options.image_config
-
-def action_list():
-    ksclient = Keystone(options.config, debug=options.debug, log=logger)
-    status = 'deactivated' if options.deactive else 'active'
-    filters = {'status': status, 'visibility': options.visibility, 'tag': tags}
-    logger.debug('=> filter: %s' % filters)
-    images = glclient.get_images(filters=filters)
-    out_image = {'header': 'Image list (id, name, created_at)'}
-    if options.format == 'text':
-        printer.output_dict(out_image)
+    images = get_image_usage()
     count = 0
-    for image in images:
-        out_image = {'name': image.name, 'created': image.created_at, 'id': image.id}
-        if options.detailed and image.visibility == 'private':
-            access = glclient.get_access(image.id)
-            if access:
-                access_list = list()
-                for member in access:
-                    project = ksclient.get_by_id('project', member['member_id'])
-                    if project:
-                        access_list.append(project.name)
-                out_image['projects'] = access_list
-        if options.detailed and hasattr(image, 'depricated'):
-            out_image['depricated'] = image.depricated
-        if options.detailed:
-            out_image['tags'] = image.tags
-        one_line = False if options.detailed else True
-        printer.output_dict(out_image, sort=True, one_line=one_line)
+    printer.output_dict({'header': 'Images deleted'})
+    for image in images.itervalues():
+        if image['count'] > 0:
+            kc.debug_log('no purge: image {} in use!'.format(image['name']))
+            continue
+        gc.delete_image(image['id'])
+        out_image = {
+            '1': image.name,
+            '2': image.created_at,
+            '3': '[' + ', '.join(image.tags) + ']'
+        }
+        printer.output_dict(out_image, sort=True, one_line=True)
         count += 1
-    out_image = {'header': 'Image count', 'count': count}
-    printer.output_dict(out_image)
+        # break purging if limit reached
+        if hasattr(options, 'limit') and options.limit >= count:
+            break
+    printer.output_dict({'header': 'Image count', 'count': count})
 
 def action_update():
-    image_templates = himutils.load_config('config/images/%s' % options.image_config)
-    if not image_templates or 'images' not in image_templates or 'type' not in image_templates:
-        sys.stderr.write("Invalid yaml file (config/images/%s): images hash not found\n"
-                         % options.image_config)
-        sys.exit(1)
-    image_type = image_templates['type']
-    for name, image_data in image_templates['images'].iteritems():
+    # Load config file
+    config_filename = 'config/images/{}'.format(options.image_config)
+    if not utils.file_exists(config_filename, logger):
+        utils.sys_error('Could not find config file {}'.format(config_filename))
+    image_config = utils.load_config('config/images/{}'.format(options.image_config))
+    if 'images' not in image_config or 'type' not in image_config:
+        utils.sys_error('Images hash not found in config file {}'.format(config_filename))
+
+    image_type = image_config['type']
+    for name, image_data in image_config['images'].iteritems():
         if options.name and name != options.name:
-            logger.debug('=> dropped %s: image name spesified', name)
+            kc.debug_log('dropped {}: image name spesified'.format(name))
             continue
-        mandatory = ['latest', 'url', 'name', 'min_ram', 'min_disk', 'depricated']
         if not bool(all(k in image_data for k in mandatory)):
-            logger.debug('=> missing attributes in image hash for %s' % name)
+            kc.debug_log('missing attributes in image hash for {}'.format(name))
             continue
         update_image(name, image_data, image_type)
 
-def image_usage(detailed=False):
-    status = 'deactivated' if options.deactive else 'active'
-    novaclient = Nova(options.config, debug=options.debug, log=logger, region=options.region)
+def get_image_usage(detailed=False):
+    if hasattr(options, 'status'):
+        status = 'deactivated' if options.status == 'deactive' else 'active'
+    else:
+        status = 'deactivated'
+    nc = utils.get_client(Nova, options, logger)
+    tags = get_tags(names=True)
     filters = {'status': status, 'visibility': options.visibility, 'tag': tags}
-    logger.debug('=> filter: %s' % filters)
+    kc.debug_log('filter: {}'.format(filters))
     image_usage = dict()
-    images = glclient.get_images(limit=1000, page_size=999, filters=filters)
+    images = gc.get_images(limit=1000, page_size=999, filters=filters)
     for image in images:
         image_usage[image.id] = image
         image_usage[image.id]['count'] = 0
         search_opts = {'image': image.id}
-        instances = novaclient.get_all_instances(search_opts=search_opts)
+        instances = nc.get_all_instances(search_opts=search_opts)
         if detailed:
             image_usage[image.id]['instances'] = list()
         for i in instances:
@@ -202,42 +193,41 @@ def update_image(name, image_data, image_type):
     else:
         checksum_type = checksum_url = None
     url = (image_data['url'] + image_data['latest'])
-    imagefile = himutils.download_file(image_data['latest'], url, logger,
-                                       checksum_type, checksum_url, 10000)
+    imagefile = utils.download_file(image_data['latest'], url, logger,
+                                    checksum_type, checksum_url, 10000)
     if not imagefile: # if download or checksum failed
-        logger.debug('=> download %s failed' % url)
+        kc.debug_log('download {} failed'.format(url))
         return
-    #tags = list(image_data['tags']) if 'tags' in image_data else list()
+    # set tags
     tags = list()
     tags.append(image_type)
     tags.append(name)
     # Filter based on tags: type and name (only one of each type should exists)
     filters = {'tag': tags, 'status': 'active'}
-    logger.debug('=> filter: %s' % filters)
-    images = glclient.find_image(filters=filters, limit=1)
+    kc.debug_log('filter: {}'.format(filters))
+    images = gc.find_image(filters=filters, limit=1)
     if images and len(images) == 1:
-        logger.debug('=> image %s found' % name)
-        checksum = himutils.checksum_file(imagefile, 'md5')
+        kc.debug_log('image {} found'.format(name))
+        checksum = utils.checksum_file(imagefile, 'md5')
         if checksum != images[0]['checksum']:
-            logger.debug('=> update image: new checksum found %s' % checksum)
+            kc.debug_log('update image: new checksum found {}'.format(checksum))
             result = create_image(name, imagefile, image_data, image_type)
-            if not options.dry_run:
-                timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
-                glclient.update_image(image_id=images[0]['id'],
-                                      name=image_data['depricated'],
-                                      depricated=timestamp)
-                glclient.deactivate(image_id=images[0]['id'])
+            timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
+            gc.update_image(image_id=images[0]['id'],
+                            name=image_data['depricated'],
+                            depricated=timestamp)
+            gc.deactivate(image_id=images[0]['id'])
         else:
             result = None
-            logger.debug('=> no new image needed: checksum match found')
+            kc.debug_log('no new image needed: checksum match found')
     else:
-        logger.debug('=> image %s not found' % name)
+        kc.debug_log('image {} not found'.format(name))
         result = create_image(name, imagefile, image_data, image_type)
     if result:
-        logger.debug('=> %s' % result)
+        kc.debug_log(result)
 
     # Cleanup
-    if os.path.isfile(imagefile):
+    if not options.skip_cleanup and os.path.isfile(imagefile):
         os.remove(imagefile)
 
 def create_image(name, source_path, image, image_type):
@@ -250,134 +240,47 @@ def create_image(name, source_path, image, image_type):
     if 'properties' in image:
         for key, value in image['properties'].iteritems():
             properties[key] = value
+    # Create tags and tag all images with type and name
     tags = list()
-    # Tag all images with type and name
     tags.append(image_type)
     tags.append(name)
     if 'tags' in image:
         for tag in image['tags']:
             tags.append(tag)
-    log_msg = "create new image %s" % image['name']
-    if not options.dry_run:
-        result = glclient.create_image(source_path,
-                                       name=image['name'],
-                                       visibility=visibility,
-                                       disk_format=disk_format,
-                                       min_disk=image['min_disk'],
-                                       min_ram=image['min_ram'],
-                                       container_format=container_format,
-                                       tags=tags,
-                                       **properties)
+    # Set image owner
+    if 'owner' in image:
+        project = kc.get_project_by_name(image['owner'])
+        if not project:
+            utils.sys_error('project {} not found!'.format(image['owner']), 0)
+            image_owner = None
+        else:
+            image_owner = project.id
     else:
-        log_msg = 'DRY-RUN: ' + log_msg
-        result = None
-    logger.debug('=> %s' % log_msg)
+        image_owner = None # no owner is set
+
+    result = gc.create_image(source_path,
+                             name=image['name'],
+                             visibility=visibility,
+                             disk_format=disk_format,
+                             min_disk=image['min_disk'],
+                             min_ram=image['min_ram'],
+                             container_format=container_format,
+                             tags=tags,
+                             owner=image_owner,
+                             **properties)
     return result
 
-def action_test():
-    novaclient = Nova(options.config, debug=options.debug, log=logger, region=options.region)
-    neutronclient = Neutron(options.config, debug=options.debug, log=logger, region=options.region)
-    filters = {'status': 'active', 'visibility': options.visibility, 'tag': tags}
-    logger.debug('=> filter: %s' % filters)
-    images = glclient.get_images(filters=filters)
-    flavors = novaclient.get_flavors('m1')
-    networks = neutronclient.list_networks()
-    secgroup_name = 'image_test-' + str(int(time.time()))
-    secgroup = neutronclient.create_security_port_group(secgroup_name, 22)
-    tests = dict({'passed': 0, 'failed': 0, 'dropped': 0})
-    for image in images:
-        if options.name and options.name not in image.tags:
-            logger.debug('=> dropped: image name %s not in tags %s', options.name,
-                         ', '.join(image.tags))
-            continue
-        for network in networks:
-            if network['name'] == 'imagebuilder':
-                continue
-            try:
-                starttime = int(time.time())
-                print '* Create instance from %s with network %s' % (image.name, network['name'])
-                flavor = glclient.find_optimal_flavor(image, flavors)
-                if not flavor:
-                    print '* Could not optimal find flavor for %s' % image.name
-                    print '-------------------------------------------------------------'
-                    continue
-                logger.debug('=> use %s flavor' % flavor.name)
-                nics = list()
-                nics.append({'net-id': network['id']})
-                server = novaclient.create_server(name='image_test'+ str(int(time.time())),
-                                                  flavor=flavor,
-                                                  image_id=image.id,
-                                                  security_groups=[secgroup['id']],
-                                                  nics=nics)
-                timeout = 300 # 5 min timeout
-                if not server:
-                    print '-------------------------------------------------------------'
-                    continue
-                server = novaclient.get_instance(server.id)
-                while timeout > 0 and server.status == 'BUILD':
-                    time.sleep(2)
-                    timeout -= 2
-                    server = novaclient.get_instance(server.id)
-                if timeout <= 0:
-                    print ('* Could not start instance from image %s in %s seconds' %
-                           (image.name, timeout))
-                if server.status == 'ERROR':
-                    print '* Instance started with error'
-                    print server.fault
-                else:
-                    used_time = int(time.time()) - starttime
-                    print '* Instance started after %s sec' % used_time
-                if server.addresses:
-                    for net in server.addresses[network['name']]:
-                        starttime = int(time.time())
-                        ip = IP(net['addr'])
-                        print ('* Instance started with IPv%s %s (%s)' %
-                               (net['version'], ip, ip.iptype()))
-                        if ip.iptype() == 'ALLOCATED RIPE NCC':
-                            print '* Drop connection check for IPv6 for now'
-                            tests['dropped'] += 1
-                            continue
-                        elif ip.iptype() == 'PRIVATE':
-                            print '* Drop connection check for rfc1918 address for now'
-                            tests['dropped'] += 1
-                            continue
-                        timeout = 90
-                        port = False
-                        while timeout > 0 and not port:
-                            start = int(time.time())
-                            port = himutils.check_port(address=str(ip), port=22, timeout=2, log=logger)
-                            time.sleep(3)
-                            timeout -= (int(time.time()) - start)
-                        used_time = int(time.time()) - starttime
-                        if port:
-                            print '* Port 22 open on %s (%s)' % (ip, ip.iptype())
-                            tests['passed'] += 1
-                        else:
-                            print ('* Unable to reach port 22 on %s after %s sec (%s)'
-                                   % (ip, used_time, ip.iptype()))
-                            tests['failed'] += 1
-                else:
-                    print '* No IP found for instances %s' % server.name
-                try:
-                    server.delete()
-                    time.sleep(3)
-                    print '* Instance deleted'
-                except:
-                    himutils.sys_error('error!!!')
-                print '-------------------------------------------------------------'
-            except KeyboardInterrupt:
-                if server:
-                    server.delete()
-                    time.sleep(5)
-                    print '* Instance deleted'
-    print '* Delete security group'
-    neutronclient.delete_security_group(secgroup['id'])
-    printer.output_dict({'header': 'Result'})
-    printer.output_dict(tests)
+def get_tags(names=False):
+    tags = list()
+    if hasattr(options, 'type'):
+        if options.type != 'all':
+            tags.append(options.type)
+    if names and options.name:
+        tags.append(options.name)
+    return tags
 
-# Run local function with the same name as the action
-action = locals().get('action_' + options.action)
+# Run local function with the same name as the action (Note: - => _)
+action = locals().get('action_' + options.action.replace('-', '_'))
 if not action:
-    logger.error("Function action_%s not implemented" % options.action)
-    sys.exit(1)
+    utils.sys_error("Function action_%s() not implemented" % options.action)
 action()

--- a/image.py
+++ b/image.py
@@ -126,6 +126,7 @@ def action_purge():
     images = get_image_usage()
     count = 0
     printer.output_dict({'header': 'Images deleted'})
+    limit = options.limit
     for image in images.itervalues():
         if image['count'] > 0:
             kc.debug_log('no purge: image {} in use!'.format(image['name']))
@@ -139,7 +140,8 @@ def action_purge():
         printer.output_dict(out_image, sort=True, one_line=True)
         count += 1
         # break purging if limit reached
-        if hasattr(options, 'limit') and options.limit >= count:
+        if limit and int(limit) >= count:
+            kc.debug_log('limit of {} reached'.format(limit))
             break
     printer.output_dict({'header': 'Image count', 'count': count})
 

--- a/image.py
+++ b/image.py
@@ -93,10 +93,12 @@ def action_usage():
     output = get_image_usage(options.detailed)
     out_image = {'header': 'Images with usage count'}
     printer.output_dict(out_image)
-    distros['header'] = 'Distros'
+    distros['header'] = 'Used distros'
     tag_count = dict()
-    tag_count['header'] = 'Tags'
+    tag_count['header'] = 'Used image tags'
+    count = 0
     for image in output.itervalues():
+        count += 1
         out_image = {
             'name': image['name'],
             'id': image['id'],
@@ -115,6 +117,7 @@ def action_usage():
                 continue
     printer.output_dict(distros)
     printer.output_dict(tag_count)
+    printer.output_dict({'header': 'Image count', 'count': count})
     return output
 
 def action_purge():

--- a/image.py
+++ b/image.py
@@ -194,6 +194,9 @@ def action_update():
 
     image_type = image_config['type']
     for name, image_data in image_config['images'].iteritems():
+        if 'retired' in image_data and image_data['retired'] == 1:
+            kc.debug_log('dropped {}: image retired'.format(name))
+            continue
         if options.name and name != options.name:
             kc.debug_log('dropped {}: image name spesified'.format(name))
             continue


### PR DESCRIPTION
**Highlights:**

* added support for `owner` attribute in image config files
* added support for `shared` visibility in config files and commands
* added new `grant`, `revoke` and `list-access` commands to manage shared images
* default tags used are `type` and `name` and most outputs can use them as filters with `-t` and `-n`
* most output and action filters work with tags, status and visibility
* `--deactive` removed and changed to new options status, `-s`, to set `active` or `deactive` images. Default is always `active`
* new option, `--skip-cleanup`, to drop image cleanup after download. Useful to use same image in testing without re-download. 

**Example:**

* create/update image: `image.py update -i cirros.yaml`
* list gold images: `image.py list -t gold`
* list deactive gold images: `image.py list -t gold -s deactive`
* purge one unused deactive gold image: `image.py purge -t gold --limit 1`
* list all shared images: `image.py list -v shared`
* list project with access to cirros shared image: `image.py list-access -n cirros`
