### PR TITLE
Revamp project grant/revoke

### DIFF
--- a/himlarcli/keystone.py
+++ b/himlarcli/keystone.py
@@ -9,11 +9,25 @@ import keystoneauth1.exceptions as exceptions
 import random
 import string
 import re
+from enum import Enum
 
 # pylint: disable=R0904
 class Keystone(Client):
 
     #version = 3
+
+    ReturnCode = Enum(
+        value="ReturnCode",
+        names=[
+            ( "OK",                0 ),
+            ( "ERROR",             1 ),
+            ( "PROJECT_NOT_FOUND", 2 ),
+            ( "GROUP_NOT_FOUND",   3 ),
+            ( "ROLE_NOT_FOUND",    4 ),
+            ( "ALREADY_MEMBER",    5 ),
+            ( "NOT_MEMBER",        6 ),
+        ],
+    )
 
     def __init__(self, config_path, debug=False, log=None):
         super(Keystone, self).__init__(config_path, debug, log)
@@ -494,36 +508,41 @@ class Keystone(Client):
 
         return "New password: %s" % password
 
-    def revoke_role(self, emails, project_name, role_name='user'):
+    def revoke_role(self, email, project_name, role_name='user'):
         """
             Revoke role for user in project
             version: 2019-3
-            :param email: list of user email address (str)
+            :param email: user email address (str)
         """
         project = self.get_project_by_name(project_name=project_name)
         if not project:
-            self.log_error("could not find project %s" % project_name, 1)
+            self.debug_log(f"could not find project {project_name}")
+            return self.ReturnCode.PROJECT_NOT_FOUND
         role = self.__get_role(role_name)
         if not role:
-            self.log_error('Role %s not found!'  % role_name)
-            return
+            self.debug_log(f'Role {role_name} not found!')
+            return self.ReturnCode.ROLE_NOT_FOUND
         assignments = self.__get_role_assignments(project_id=project.id, role_id=role.id)
-        for email in emails:
-            group = self.get_group_by_email(email=email)
-            if not group:
-                self.log_error('Group %s-group not found!'  % email)
-                continue
-            if group.name not in assignments:
-                self.debug_log('%s not found in assignments. dropping revoke' % group.name)
-                continue
-            self.debug_log('revoke role %s to %s for %s' % (role.name, email, project_name))
-            if not self.dry_run:
-                try:
-                    self.client.roles.revoke(role=role,
-                                             project=project,
-                                             group=group)
-                except exceptions.base.ClientException as e:
-                    self.log_error(e)
+        group = self.get_group_by_email(email=email)
+        if not group:
+            self.debug_log(f'Group {email}-group not found!')
+            return self.ReturnCode.GROUP_NOT_FOUND
+        if group.name not in assignments:
+            self.debug_log(f'{group.name} not found in assignments. dropping revoke')
+            return self.ReturnCode.NOT_MEMBER
+        if self.dry_run:
+            data = {'user':group.name, 'project': project_name, 'role':role.name}
+            self.log_dry_run(function='revoke_role', **data)
+        else:
+            try:
+                self.client.roles.revoke(role=role,
+                                         project=project,
+                                         group=group)
+            except exceptions.base.ClientException as e:
+                self.log_error(e)
+                return self.ReturnCode.ERROR
+        self.debug_log(f'revoke role {role.name} to {email} for {project_name}')
+        return self.ReturnCode.OK
 
     def grant_role(self, email, project_name, role_name='user'):
         """ Grant a role to a project for a user.
@@ -531,18 +550,19 @@ class Keystone(Client):
         if not self.dry_run:
             project = self.get_project_by_name(project_name=project_name)
         if not self.dry_run and not project:
-            self.log_error("could not find project %s" % project_name, 1)
+            self.debug_log(f"could not find project {project_name}")
+            return self.ReturnCode.PROJECT_NOT_FOUND
         if '-group' in email:
             group = self.__get_group(email)
         else:
             group = self.get_group_by_email(email=email)
         if not group:
-            self.log_error('Group %s-group not found!'  % email)
-            return
+            self.debug_log(f'Group {email}-group not found!')
+            return self.ReturnCode.GROUP_NOT_FOUND
         role = self.__get_role(role_name)
         if not role:
-            self.log_error('Role %s not found!'  % role_name)
-            return
+            self.log_error(f'Role {role_name} not found!')
+            return self.ReturnCode.ROLE_NOT_FOUND
         exists = None
         try:
             if not self.dry_run:
@@ -553,16 +573,22 @@ class Keystone(Client):
                         continue
         except exceptions.http.NotFound as e:
             self.log_error(e)
-        self.logger.debug('=> grant role %s to %s for %s', role.name, email, project_name)
         if exists:
-            self.log_error('Role %s exist for %s in project %s' % (role.name, email, project_name))
-        elif self.dry_run:
+            self.debug_log(f'Role {role.name} already exists for {email} in project {project_name}')
+            return self.ReturnCode.ROLE_ALREADY_EXISTS
+        if self.dry_run:
             data = {'user':group.name, 'project': project_name, 'role':role.name}
             self.log_dry_run(function='grant_role', **data)
         else:
-            self.client.roles.grant(role=role,
-                                    project=project,
-                                    group=group)
+            try:
+                self.client.roles.grant(role=role,
+                                        project=project,
+                                        group=group)
+            except exceptions.base.ClientException as e:
+                self.log_error(e)
+                return self.ReturnCode.ERROR
+        self.debug_log(f'grant role {role.name} to {email} for {project_name}')
+        return self.ReturnCode.OK
 
     def list_roles(self, project_name, domain=None):
         """ List all roles for a project based on project name.

--- a/notify/access_granted_rt.txt
+++ b/notify/access_granted_rt.txt
@@ -1,6 +1,6 @@
 Hi,
 
-Access has been granted to the following users:
+New members added in project $project:
 
 $users
 

--- a/notify/access_revoked_rt.txt
+++ b/notify/access_revoked_rt.txt
@@ -1,6 +1,6 @@
 Hi,
 
-Access has been revoked for the following users:
+Membership in project $project revoked for the following users:
 
 $users
 

--- a/object.py
+++ b/object.py
@@ -8,6 +8,8 @@ from himlarcli.parser import Parser
 from himlarcli.printer import Printer
 from himlarcli import utils as himutils
 
+import re
+
 parser = Parser()
 options = parser.parse_args()
 printer = Printer(options.format)
@@ -23,28 +25,44 @@ else:
     regions = ksclient.find_regions()
 
 if not regions:
-    himutils.sys_error('No valid regions found!')
+    himutils.fatal('No valid regions found!')
 
 def action_grant():
-    # Get all users from a project
-    users = ksclient.list_roles(project_name=options.project)
-    for user in users:
-        if user['role'] is not 'object':
-            ksclient.grant_role(email=user['group'], project_name=options.project, role_name='object')
-
-def action_revoke():
+    # Get project, make sure it is valid
     project = ksclient.get_project_by_name(project_name=options.project)
     if not project:
-        himutils.sys_error('No project found with name %s' % options.project)
-    # Get all users from a project
-    users = ksclient.get_users(domain=options.domain, project=project.id)
-    emails = list()
+        himutils.fatal(f'Project not found: {options.project}')
+
+    # Get all users from project
+    users = ksclient.list_roles(project_name=options.project)
+
+    # Grant object role for all users
     for user in users:
-        emails.append(user.email)
-    ksclient.revoke_role(emails=emails, project_name=project.name, role_name='object')
+        rc = ksclient.grant_role(email=user['group'], project_name=options.project, role_name='object')
+        if rc == ksclient.ReturnCode.OK:
+            himutils.info(f"Granted object access in {options.project} to {user.group}")
+        elif rc == ksclient.ReturnCode.ALREADY_MEMBER:
+            himutils.warning(f"User {user.group} already has object access in {options.project}")
+
+def action_revoke():
+    # Get project, make sure it is valid
+    project = ksclient.get_project_by_name(project_name=options.project)
+    if not project:
+        himutils.fatal(f'Project not found: {options.project}')
+
+    # Get all users from project
+    users = ksclient.list_roles(project_name=options.project)
+
+    # Revoke object role for all users
+    for user in users:
+        if user['role'] == 'object':
+            email = re.sub('(-group|-disabled)$', '', user['group'])
+            rc = ksclient.revoke_role(email=email, project_name=options.project, role_name='object')
+            if rc == ksclient.ReturnCode.OK:
+                himutils.info(f"Revoked object access in {options.project} from {email}")
 
 # Run local function with the same name as the action
 action = locals().get('action_' + options.action)
 if not action:
-    himutils.sys_error("Function action_%s() not implemented" % options.action)
+    himutils.fatal(f"Function action_{options.action}() not implemented")
 action()

--- a/project.py
+++ b/project.py
@@ -259,81 +259,107 @@ def action_extend():
 
 
 def action_grant():
+    # Collect info
+    granted_users = []
+    invalid_users = []
+
+    # Get project, make sure it is valid and correct type
+    project = ksclient.get_project_by_name(project_name=options.project)
+    if not project:
+        himutils.fatal(f'Project not found: {options.project}')
+    if hasattr(project, 'type') and (project.type == 'demo' or project.type == 'personal'):
+        himutils.fatal(f'Project is {project.type}. User access not allowed!')
+
+    # Add users to project
     for user in options.users:
         if not ksclient.is_valid_user(email=user, domain=options.domain):
-            himutils.sys_error('User %s not found as a valid user.' % user)
-        project = ksclient.get_project_by_name(project_name=options.project)
-        if not project:
-            himutils.sys_error('No project found with name "%s"' % options.project)
-        if hasattr(project, 'type') and (project.type == 'demo' or project.type == 'personal'):
-            himutils.sys_error('Project are %s. User access not allowed!' % project.type)
-        role = ksclient.grant_role(project_name=options.project,
-                                   email=user)
-        if role:
-            output = role.to_dict() if not isinstance(role, dict) else role
-            output['header'] = "Roles for %s" % options.project
-            printer.output_dict(output)
+            himutils.error(f"User not found: {user}")
+            invalid_users.append(user)
+        rc = ksclient.grant_role(project_name=options.project,
+                                 email=user)
+        if rc == ksclient.ReturnCode.OK:
+            himutils.info(f"Granted membership to {options.project} for {user}")
+            granted_users.append(user)
+        elif rc == ksclient.ReturnCode.ALREADY_MEMBER:
+            himutils.warning(f"User {user} is already a member of {options.project}")
 
-    if options.mail:
+    # Send email to the added users, and update RT
+    if len(granted_users) > 0 and options.mail:
         mail = Mail(options.config, debug=options.debug)
         mail.set_dry_run(options.dry_run)
 
-        if options.rt is None:
-            himutils.sys_error('--rt parameter is missing.')
-        else:
-            rt_mapping = dict(users='\n'.join(options.users))
-            rt_subject = 'NREC: Access granted to users in %s' % options.project
+        if options.rt is not None:
+            rt_mapping = {
+                'users'   : '\n'.join(granted_users),
+                'project' : options.project,
+            }
+            rt_subject = f'[NREC] Access granted to users in {options.project}'
             rt_body_content = himutils.load_template(inputfile=access_granted_msg_file,
                                                      mapping=rt_mapping)
 
-        rt_mime = mail.rt_mail(options.rt, rt_subject, rt_body_content)
-        mail.send_mail('support@nrec.no', rt_mime)
+            rt_mime = mail.rt_mail(options.rt, rt_subject, rt_body_content)
+            mail.send_mail('support@nrec.no', rt_mime)
 
-        for user in options.users:
-            mapping = dict(project_name=options.project, admin=project.admin)
+        for user in granted_users:
+            mapping = {
+                'project_name' : options.project,
+                'admin'        : project.admin,
+            }
             body_content = himutils.load_template(inputfile=access_granted_user_msg_file,
                                                   mapping=mapping)
             msg = MIMEText(body_content, 'plain')
-            msg['subject'] = 'NREC: You have been given access to project %s' % options.project
-
+            msg['subject'] = f'[NREC] You have been given access to project {options.project}'
             mail.send_mail(user, msg, fromaddr='noreply@nrec.no')
 
 def action_revoke():
+    # Collect info
+    revoked_users = []
+    invalid_users = []
+
+    # Get project, make sure it is valid and correct type
+    project = ksclient.get_project_by_name(project_name=options.project)
+    if not project:
+        himutils.fatal(f'Project not found: {options.project}')
+
+    # Remove users from project
     for user in options.users:
         if not ksclient.is_valid_user(email=user, domain=options.domain):
-            himutils.sys_error('User %s not found as a valid user.' % user)
-        project = ksclient.get_project_by_name(project_name=options.project)
-        if not project:
-            himutils.sys_error('No project found with name "%s"' % options.project)
-        role = ksclient.revoke_role(project_name=options.project,
-                                    emails=[user])
-        if role:
-            output = role.to_dict() if not isinstance(role, dict) else role
-            output['header'] = "Roles for %s" % options.project
-            printer.output_dict(output)
+            himutils.error(f"User not found: {user}")
+            invalid_users.append(user)
+            continue
+        rc = ksclient.revoke_role(project_name=options.project,
+                                    email=user)
+        if rc == ksclient.ReturnCode.OK:
+            himutils.info(f"Revoked membership from {options.project} for {user}")
+            revoked_users.append(user)
+        elif rc == ksclient.ReturnCode.NOT_MEMBER:
+            himutils.warning(f"User {user} is not a member of {options.project}")
 
-    if options.mail:
+    if len(revoked_users) > 0 and options.mail:
         mail = Mail(options.config, debug=options.debug)
         mail.set_dry_run(options.dry_run)
 
-        if options.rt is None:
-            himutils.sys_error('--rt parameter is missing.')
-        else:
-            rt_mapping = dict(users='\n'.join(options.users))
-            rt_subject = 'NREC: Access revoked for users in %s' % options.project
+        if options.rt is not None:
+            rt_mapping = {
+                'users'   : '\n'.join(revoked_users),
+                'project' : options.project,
+            }
+            rt_subject = f'[NREC] Access revoked for users in {options.project}'
             rt_body_content = himutils.load_template(inputfile=access_revoked_msg_file,
                                                      mapping=rt_mapping)
 
-        rt_mime = mail.rt_mail(options.rt, rt_subject, rt_body_content)
-        mail.send_mail('support@nrec.no', rt_mime)
+            rt_mime = mail.rt_mail(options.rt, rt_subject, rt_body_content)
+            mail.send_mail('support@nrec.no', rt_mime)
 
-        for user in options.users:
-            mapping = dict(project_name=options.project, admin=project.admin)
+        for user in revoked_users:
+            mapping = {
+                'project_name' : options.project,
+                'admin'        : project.admin,
+            }
             body_content = himutils.load_template(inputfile=access_revoked_user_msg_file,
                                                   mapping=mapping)
             msg = MIMEText(body_content, 'plain')
-            msg['subject'] = 'NREC: Your access to project %s is revoked' % options.project
-
+            msg['subject'] = f'[NREC] Your access to project {options.project} is revoked'
             mail.send_mail(user, msg, fromaddr='noreply@nrec.no')
 
 def action_delete():


### PR DESCRIPTION
Noteworthy changes:

- 'project grant/revoke' no longer exits on first username that is wrong
- Option '-m' can now be used without option '--rt'. Use '-m' to send mail to the added user, add '--rt' to update RT as well
- role_grant() and role_revoke() in keystone.py now work the same way and expect the same parameters
- object.py has been updated to reflect changes in keystone.py