### PR TITLE
Periodically update windows images

### DIFF
--- a/bin/image_update.sh
+++ b/bin/image_update.sh
@@ -12,3 +12,7 @@ sleep 60
 
 # vgpu images
 /opt/himlarcli/image.py update -i vgpu.yaml
+sleep 300
+
+# Windows images
+/opt/himlarcli/image.py update -i windows.yaml


### PR DESCRIPTION
Even though windows images are now build in all regions, they are not uploaded to glance. There is no reason for not doing this. This should not be merged until the new version of packer-windows is tested.