### PR TITLE
fix: remove en_DK.UTF-8 setting

### DIFF
--- a/himlarcli/printer.py
+++ b/himlarcli/printer.py
@@ -14,8 +14,6 @@ import csv
 from collections import OrderedDict
 import locale
 
-locale.setlocale(locale.LC_ALL, 'en_DK.UTF-8')
-
 class Printer(object):
 
     VALID_OPTIONS = ['text', 'table', 'json', 'csv']


### PR DESCRIPTION
This line causes problems with himlarcli. Tested on hosts RHEL 9, Ubuntu 22 and guest AlmaLinux 8.9 (vagrant-proxy-01)

./hypervisor.py list --format table
Traceback (most recent call last):
  File "/home/ivar/Projects/himlarcli/./hypervisor.py", line 11, in <module>
    from himlarcli.parser import Parser
  File "/home/ivar/Projects/himlarcli/himlarcli/parser.py", line 5, in <module>
    from himlarcli.printer import Printer
  File "/home/ivar/Projects/himlarcli/himlarcli/printer.py", line 17, in <module>
    locale.setlocale(locale.LC_ALL, 'en_DK.UTF-8')
  File "/usr/lib/python3.10/locale.py", line 620, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting