### PR TITLE
Fixed Python 3 compatibility bugs

### DIFF
--- a/himlarcli/client.py
+++ b/himlarcli/client.py
@@ -5,15 +5,14 @@ import unicodedata
 from keystoneauth1.identity import v3
 from keystoneauth1 import session
 from himlarcli import utils
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 
-class Client(object):
+class Client(ABC):
 
     """ Constant used to mark a class as region aware """
     USE_REGION = False
 
-    __metaclass__ = ABCMeta
     region = None
 
     def __init__(self, config_path, debug, log=None, region=None):

--- a/himlarcli/mail.py
+++ b/himlarcli/mail.py
@@ -133,12 +133,12 @@ class Mail(Client):
             if admin:
                 users[email][i.name]['project'] = project.name
         # Send mail
-        for user, instances in users.iteritems():
+        for user, instances in users.items():
             user_instances = (
                 "You are receiving this e-mail because you (or a team you're part of)\n"
                 "have the following instances running in NREC.\n\n"
             )
-            for server, info in instances.iteritems():
+            for server, info in instances.items():
                 extra = list()
                 for option in options:
                     extra.append(info[option])

--- a/himlarcli/notify.py
+++ b/himlarcli/notify.py
@@ -86,12 +86,12 @@ class Notify(object):
             if admin:
                 users[email][i.name]['project'] = project.name
         # Send mail
-        for user, instances in users.iteritems():
+        for user, instances in users.items():
             user_instances = (
                 "You are receiving this e-mail because you (or a team you're part of)\n"
                 "have the following instances running in UH-IaaS:\n\n"
             )
-            for server, info in instances.iteritems():
+            for server, info in instances.items():
                 extra = list()
                 for option in options:
                     extra.append(info[option])

--- a/himlarcli/state.py
+++ b/himlarcli/state.py
@@ -151,7 +151,7 @@ class Quota(Base):
 
     def compare(self, attributes):
         miss_match = {}
-        for k, v in attributes.iteritems():
+        for k, v in attributes.items():
             if k == 'id':
                 continue
             if k not in Quota.__dict__:

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -44,7 +44,7 @@ def config_file(config_path):
             tests = yaml.full_load(template)
         except yaml.YAMLError as e:
             print(e)
-    for section, options in tests.iteritems():
+    for section, options in tests.items():
         if not config.has_section(section):
             print("Missing section [%s]" % section)
             sys.exit(1)


### PR DESCRIPTION
Five changes made across five files:
 
- himlarcli/client.py      class `Client(ABC)` instead of `Client(object)` + `__metaclass__`; import `ABC` instead of `ABCMeta`
- himlarcli/notify.py:89,94  `.iteritems()` → `.items()`
- himlarcli/mail.py:136,141  `.iteritems()` → `.items()`
- himlarcli/state.py:154    `.iteritems()` → `.items()`
- tests/setup_test.py:47    `.iteritems()` → `.items()`

The client.py change is the most important — Client will now actually enforce `@abstractmethod` on subclasses in Python 3, which was silently broken before.