### PR TITLE
feat(osl): atlas3 flavors

### DIFF
--- a/config/flavors/atlas3.yaml
+++ b/config/flavors/atlas3.yaml
@@ -1,0 +1,33 @@
+---
+# https://iaas.readthedocs.io/team/tips_and_tricks/dedicated-flavors.html
+public: false
+properties:
+  hw_rng:allowed: 'True'
+  hw_rng:rate_bytes: 2048
+  hw_rng:rate_period: 1
+  hw:numa_nodes: 1
+  hw:cpu_sockets: 1
+  hw:cpu_policy: 'dedicated'
+  hw:cpu_thread_policy: 'require'
+  hw:mem_page_size: 2048
+  trait:CUSTOM_NREC_ATLAS3: 'required'
+  'atlas3.32-cores':
+    vcpus: 32
+    ram:   128797
+    disk:  146
+  'atlas3.48-cores':
+    vcpus: 48
+    ram:   193196
+    disk:  219
+  'atlas3.64-cores':
+    vcpus: 64
+    ram:   257595
+    disk:  292
+  'atlas3.96-cores':
+    vcpus: 96
+    ram:   386392
+    disk:  438
+  'atlas3.192-cores':
+    vcpus: 192
+    ram:   772785
+    disk:  876


### PR DESCRIPTION
ram og disk er funnet slik:

RAM (MiB):

Per core

echo '772785/192' | bc -l
4024.92187500000000000000

Flavors

echo '4024.92187500000000000000*32' | bc -l
128797.50000000000000000000

echo '4024.92187500000000000000*48' | bc -l
193196.25000000000000000000

echo '4024.92187500000000000000*64' | bc -l
257595.00000000000000000000

echo '4024.92187500000000000000*96' | bc -l
386392.50000000000000000000

echo '4024.92187500000000000000*192' | bc -l
772785.00000000000000000000

DISK (GiB):

Per core

echo '877/192' | bc -l
4.56770833333333333333

Flavors

echo '4.56770833333333333333*32' | bc -l
146.16666666666666666656

echo '4.56770833333333333333*48' | bc -l
219.24999999999999999984

echo '4.56770833333333333333*64' | bc -l
292.33333333333333333312

echo '4.56770833333333333333*96' | bc -l
438.49999999999999999968

echo '4.56770833333333333333*192' | bc -l
876.99999999999999999936