### PR TITLE
Add smaller flavors to bgo shpc c1 variants

### DIFF
--- a/config/flavors/shpc.c1a-bgo.yaml
+++ b/config/flavors/shpc.c1a-bgo.yaml
@@ -7,6 +7,14 @@ properties:
   hw_rng:rate_period: 1
   aggregate_instance_extra_specs:type: 's== shpc_cpu'
 shpc.c1a:
+  'shpc.c1a.large': 
+    vcpus: 2 
+    ram: 4096
+    disk: 20
+  'shpc.c1a.xlarge': 
+    vcpus: 4
+    ram: 8192
+    disk: 20
   'shpc.c1a.2xlarge':
     vcpus: 8
     ram: 16384

--- a/config/flavors/shpc.c1ad0-bgo.yaml
+++ b/config/flavors/shpc.c1ad0-bgo.yaml
@@ -7,6 +7,14 @@ properties:
   hw_rng:rate_period: 1
   aggregate_instance_extra_specs:type: 's== shpc_cpu'
 shpc.c1ad0:
+  'shpc.c1ad0.large': 
+    vcpus: 2 
+    ram: 4096
+    disk: 80
+  'shpc.c1ad0.xlarge': 
+    vcpus: 4
+    ram: 8192
+    disk: 80
   'shpc.c1ad0.2xlarge':
     vcpus: 8
     ram: 16384

--- a/config/flavors/shpc.c1ad1-bgo.yaml
+++ b/config/flavors/shpc.c1ad1-bgo.yaml
@@ -7,6 +7,14 @@ properties:
   hw_rng:rate_period: 1
   aggregate_instance_extra_specs:type: 's== shpc_cpu'
 shpc.c1ad1:
+  'shpc.c1ad1.large': 
+    vcpus: 2 
+    ram: 4096
+    disk: 200
+  'shpc.c1ad1.xlarge': 
+    vcpus: 4
+    ram: 8192
+    disk: 200
   'shpc.c1ad1.2xlarge':
     vcpus: 8
     ram: 16384

--- a/config/flavors/shpc.c1ad2-bgo.yaml
+++ b/config/flavors/shpc.c1ad2-bgo.yaml
@@ -7,6 +7,14 @@ properties:
   hw_rng:rate_period: 1
   aggregate_instance_extra_specs:type: 's== shpc_cpu'
 shpc.c1ad2:
+  'shpc.c1ad2.large': 
+    vcpus: 2 
+    ram: 4096
+    disk: 500
+  'shpc.c1ad2.xlarge': 
+    vcpus: 4
+    ram: 8192
+    disk: 500
   'shpc.c1ad2.2xlarge':
     vcpus: 8
     ram: 16384

--- a/config/flavors/shpc.c1ad3-bgo.yaml
+++ b/config/flavors/shpc.c1ad3-bgo.yaml
@@ -7,6 +7,14 @@ properties:
   hw_rng:rate_period: 1
   aggregate_instance_extra_specs:type: 's== shpc_cpu'
 shpc.c1ad3:
+  'shpc.c1ad3.large': 
+    vcpus: 2 
+    ram: 4096
+    disk: 1000
+  'shpc.c1ad3.xlarge': 
+    vcpus: 4
+    ram: 8192
+    disk: 1000
   'shpc.c1ad3.2xlarge':
     vcpus: 8
     ram: 16384

--- a/config/flavors/shpc.c1ad4-bgo.yaml
+++ b/config/flavors/shpc.c1ad4-bgo.yaml
@@ -7,6 +7,14 @@ properties:
   hw_rng:rate_period: 1
   aggregate_instance_extra_specs:type: 's== shpc_cpu'
 shpc.c1ad4:
+  'shpc.c1ad4.large': 
+    vcpus: 2 
+    ram: 4096
+    disk: 2000
+  'shpc.c1ad4.xlarge': 
+    vcpus: 4
+    ram: 8192
+    disk: 2000  
   'shpc.c1ad4.2xlarge':
     vcpus: 8
     ram: 16384


### PR DESCRIPTION
## Summary

Adds smaller SHPC C1 BGO flavors across the existing C1 and C1AD variants.

This introduces `large` and `xlarge` flavor definitions for:

* `shpc.c1a-bgo`
* `shpc.c1ad0-bgo`
* `shpc.c1ad1-bgo`
* `shpc.c1ad2-bgo`
* `shpc.c1ad3-bgo`
* `shpc.c1ad4-bgo`

## Changes

* Adds 2 vCPU / 4 GB RAM `large` flavors
* Adds 4 vCPU / 8 GB RAM `xlarge` flavors
* Keeps disk sizes aligned with each existing variants:

  * `c1a`: 20 GB
  * `c1ad0`: 80 GB
  * `c1ad1`: 200 GB
  * `c1ad2`: 500 GB
  * `c1ad3`: 1000 GB
  * `c1ad4`: 2000 GB

## Motivation

The existing SHPC C1 BGO flavor variants only provide larger instance sizes. However most usecases have proven not to require disk sizes. We have encountered usecases where it would be beneficial to use the local storage of the hypervisors using data that can be rebuilt. This will reduce the demand for mass-storage-ssd in the bgo region.  However in many cases these usecases does not require the larger compute and memory instance sizes and thus would end up hogging resources if used. The proposed solution is these smaller flavor sizes.
