### PR TITLE
keep flavor access when updating flavors

### DIFF
--- a/flavor.py
+++ b/flavor.py
@@ -67,7 +67,8 @@ def action_instances():
 
 def action_update():
     question = ("This will delete the flavor and recreate it for all other "
-                "changes than properties. Check project access after. Continue?")
+                "changes than properties. Project access is restored for the "
+                "recreated flavors. Continue?")
     if not himutils.confirm_action(question):
         return
 
@@ -83,7 +84,10 @@ def action_update():
 
         nc = Nova(options.config, debug=options.debug, log=logger, region=region)
         nc.set_dry_run(options.dry_run)
-        access = nc.get_flavor_access(filters=options.flavor)
+        # Project access per flavor before the update, so that it can be
+        # restored for the flavors that are recreated. Public flavors have
+        # no project access.
+        old_access = dict() if public else get_current_access(nc)
         for name, spec in sorted(flavors[options.flavor].items()):
             # Hack to override properties per flavor
             flavor_properties = properties.copy()
@@ -91,19 +95,20 @@ def action_update():
                 for p_name, prop in spec['properties'].items():
                     flavor_properties[p_name] = prop
                 del spec['properties']
-            nc.update_flavor(name=name, spec=spec,
-                             properties=flavor_properties, public=public)
-        # Update access
-        all_projects = set()
-        for name, projects in access.items():
-            for project_id in projects:
-                all_projects.add(project_id.tenant_id)
-        for project in all_projects:
-            # only keep access if project still exists
-            if kc.get_by_id('project', project):
-                nc.update_flavor_access(class_filter=options.flavor,
-                                        project_id=project,
-                                        action='grant')
+            result = nc.update_flavor(name=name, spec=spec,
+                                      properties=flavor_properties, public=public)
+            # Only a recreated flavor has a new id and has lost its access
+            if result != 'recreated' or not old_access.get(name):
+                continue
+            granted = nc.update_flavor_access_by_name(flavor_name=name,
+                                                      project_ids=old_access[name],
+                                                      action='grant')
+            printer.output_msg('%s recreated in %s, restored access for %s project(s)'
+                               % (name, region, len(granted)))
+            if len(granted) != len(old_access[name]):
+                himutils.sys_error('failed to restore access to %s in %s for: %s'
+                                   % (name, region,
+                                      ', '.join(set(old_access[name]) - set(granted))), 0)
 
 def action_purge():
     q = 'Purge flavors from class {} in region(s) {}'.format(options.flavor, ','.join(regions))
@@ -202,6 +207,20 @@ def get_flavor_config(region):
         himutils.sys_error('Could not find flavor config file config/flavors/%s.yaml'
                            % options.flavor)
     return flavors
+
+def get_current_access(nc):
+    """ Map flavor name to the list of project ids with access to that flavor.
+        Projects that no longer exist are dropped. """
+    access = dict()
+    for name, projects in nc.get_flavor_access(filters=options.flavor).items():
+        access[name] = list()
+        for project_id in projects:
+            # only keep access if project still exists
+            if kc.get_by_id('project', project_id.tenant_id):
+                access[name].append(project_id.tenant_id)
+            else:
+                himutils.sys_error('project not found %s' % project_id.tenant_id, 0)
+    return access
 
 def update_access(nc, access_action, region):
     flavors = get_flavor_config(region)

--- a/himlarcli/nova.py
+++ b/himlarcli/nova.py
@@ -565,12 +565,17 @@ class Nova(Client):
         """
         Update flavor with new spec or propertiesself.
         Note: Update require a delete and create with new ID
-        Version: 2022-7
+        Version: 2026-7
+        :rtype: str with the action taken on the flavor itself: created,
+                recreated or unchanged. Note that a recreated flavor has a
+                new ID and has lost all project access.
         """
         dry_run_txt = ' DRY_RUN:' if self.dry_run else ''
         flavor = self.get_by_name('flavor', name)
+        result = 'unchanged'
         if not flavor:
             # Create new flavor
+            result = 'created'
             self.logger.debug('=>%s create flavor %s', dry_run_txt, name)
             if not self.dry_run:
                 flavor = self.client.flavors.create(name=name,
@@ -586,6 +591,7 @@ class Nova(Client):
             if flavor and v != getattr(flavor, k):
                 update = True
         if update:
+            result = 'recreated'
             self.logger.debug('=>%s update flavor %s', dry_run_txt, name)
             if not self.dry_run:
                 # delete old
@@ -598,7 +604,7 @@ class Nova(Client):
                                                     is_public=public)
         # if no flavor we cannot do properties
         if not flavor:
-            return
+            return result
         # Unset old properties
         for k, v in flavor.get_keys().items():
             if k not in properties:
@@ -608,7 +614,7 @@ class Nova(Client):
         # Add new properties
         update = False
         if not properties:
-            return
+            return result
         flavor_keys = flavor.get_keys()
         for k, v in properties.items():
             # flavor keys return everything as unicode so we use string match
@@ -619,6 +625,7 @@ class Nova(Client):
                         flavor.set_keys({k:v})
                     except novaclient.exceptions.BadRequest as e:
                         self.logger.debug('=> %s', e)
+        return result
 
     def get_flavors(self, class_filter=None, sort_key='memory_mb', sort_dir='asc'):
         """
@@ -711,6 +718,40 @@ class Nova(Client):
                 self.logger.debug('=> unable to %s %s' %
                                   (action, flavor.name))
         return access_updated
+
+    def update_flavor_access_by_name(self, flavor_name, project_ids, action='grant'):
+        """
+            Grant or revoke access to a single flavor for a list of projects
+            Version: 2026-7
+            :param flavor_name: name of the flavor, e.g. m1.medium
+            :param project_ids: list of project ids
+            :rtype: List of project ids where the access was updated
+        """
+        dry_run_txt = 'DRY-RUN: ' if self.dry_run else ''
+        if action == 'revoke':
+            action_func = 'remove_tenant_access'
+        else:
+            action_func = 'add_tenant_access'
+        flavor = self.get_by_name('flavor', flavor_name)
+        if not flavor:
+            self.debug_log('flavor {} not found'.format(flavor_name))
+            return []
+        updated = list()
+        for project_id in project_ids:
+            try:
+                if not self.dry_run:
+                    getattr(self.client.flavor_access, action_func)(flavor.id,
+                                                                    project_id)
+                self.logger.debug('=> %s%s access to %s for project %s' %
+                                  (dry_run_txt, action, flavor_name, project_id))
+                updated.append(project_id)
+            except novaclient.exceptions.Conflict:
+                self.logger.debug('=> access exsists for %s and project %s' %
+                                  (flavor_name, project_id))
+            except novaclient.exceptions.NotFound:
+                self.logger.debug('=> unable to %s %s for project %s' %
+                                  (action, flavor_name, project_id))
+        return updated
 
     def get_flavor_access(self, filters):
         flavors = self.get_flavors(filters)


### PR DESCRIPTION
● Done. Here's what changed.

  The old behavior (flavor.py:96-106) did try to restore access, but it flattened it: it collected the union of every project across every
  flavor in the class and granted that whole set to all flavors in the class — so per-flavor access was widened, and access was re-granted
  even for flavors that were never recreated.

  himlarcli/nova.py
  - update_flavor() now returns what it did to the flavor: 'created', 'recreated', or 'unchanged'. Only 'recreated' (delete + create → new
  ID) loses project access; property-only changes keep the ID and the access. It was the only caller-relevant piece of information missing,
  and flavor.py:97 was the sole caller, so no other code is affected. 
  - New update_flavor_access_by_name(flavor_name, project_ids, action='grant') — grants/revokes for a single flavor for a list of projects,
  and returns the list of project ids it actually updated. The existing update_flavor_access() only works on a whole flavor class, which is
  what forced the coarse behavior.

  flavor.py
  - New get_current_access(nc) helper builds {flavor_name: [project_id, ...]} from nc.get_flavor_access() before anything is touched,
  dropping projects that no longer exist (warns on stderr, same as list-access does).
  - action_update() snapshots that map up front, then per flavor: if update_flavor() reports 'recreated' and that flavor had access, it
  re-grants exactly the projects that flavor had. Unchanged and newly created flavors are left alone. Skipped entirely when the class is
  public: true, since public flavors have no project access.
  - Reports each restore via printer.output_msg, and errors (without exiting) if any project failed to be re-granted.
  - Confirmation prompt no longer says "Check project access after."

  pylint -E is clean on flavor.py; himlarcli/nova.py has one pre-existing unrelated error (urllib2 undefined at himlarcli/nova.py:503). I
  have no cloud to run this against, so it's not verified end-to-end — ./flavor.py update --flavor <class> --dry-run --debug will show the
  recreated/restore decisions in the debug log without mutating anything.

✻ Cooked for 2m 43s

※ recap: Goal was to make flavor.py update preserve per-flavor project access across recreation; that's implemented in flavor.py and 
  himlarcli/nova.py and passes pylint. Next: run ./flavor.py update --flavor <class> --dry-run --debug against a real region to verify. 
  (disable recaps in /config)
